### PR TITLE
Review progress and type system next steps

### DIFF
--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -1580,12 +1580,20 @@ const parsePattern: C.Parser<Pattern> = C.choice(
   })
 );
 
+// --- Match Case Expression Parser ---
+// This parser supports expressions in match cases, including nested match expressions
+const parseMatchCaseExpression: C.Parser<Expression> = C.choice(
+  C.lazy(() => parseMatchExpression), // Support nested match expressions
+  parseIfExpression, // Support if expressions  
+  C.lazy(() => parseExprWithType) // Support all other expressions including type annotations
+);
+
 // --- Match Case ---
 const parseMatchCase: C.Parser<MatchCase> = C.map(
   C.seq(
     parsePattern,
     C.operator("=>"),
-    C.lazy(() => parseThrush) // Use simpler expression parser to avoid circular dependency
+    C.lazy(() => parseMatchCaseExpression) // Use dedicated parser for match case expressions
   ),
   ([pattern, arrow, expression]): MatchCase => ({
     pattern,


### PR DESCRIPTION
Fix parsing of nested match expressions within ADT match cases to support full expression hierarchy.

The `parseMatchCase` function previously used `parseThrush`, which did not include `match` expressions in its hierarchy. This prevented parsing of nested match expressions like `Ok opt => match opt with (Some x => x; None => 0)`, causing 2 tests to fail. This PR introduces a new `parseMatchCaseExpression` that correctly includes `parseMatchExpression` and `parseIfExpression` using lazy evaluation to resolve circular dependencies, ensuring all 502 tests pass.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-d999b982-9c68-4f72-bc8c-d7501074c654) · [Cursor](https://cursor.com/background-agent?bcId=bc-d999b982-9c68-4f72-bc8c-d7501074c654)

Learn more about [Background Agents](https://docs.cursor.com/background-agents)