### PR TITLE
Fix float numeric and add implementations

### DIFF
--- a/src/typer/builtins.ts
+++ b/src/typer/builtins.ts
@@ -432,8 +432,48 @@ export const initializeBuiltins = (state: TypeState): TypeState => {
 		});
 	}
 	
-	// Basic trait implementations are handled directly in constraint resolution
-	// to avoid circular dependency issues with primitive function loading
+	// Add basic trait implementations for built-in types
+	// These are needed for runtime trait function resolution in the evaluator
+	
+	// Create a minimal location for built-in implementations
+	const builtinLocation = {
+		start: { line: 0, column: 0 },
+		end: { line: 0, column: 0 }
+	};
+	
+	// Implement Add for Float
+	try {
+		addTraitImplementation(newState.traitRegistry, 'Add', {
+			typeName: 'Float',
+			functions: new Map([['add', { kind: 'variable', name: 'primitive_float_add', location: builtinLocation }]])
+		});
+	} catch (e) {
+		// Implementation may already exist from stdlib - that's ok
+	}
+	
+	// Implement Add for String
+	try {
+		addTraitImplementation(newState.traitRegistry, 'Add', {
+			typeName: 'String',
+			functions: new Map([['add', { kind: 'variable', name: 'primitive_string_concat', location: builtinLocation }]])
+		});
+	} catch (e) {
+		// Implementation may already exist from stdlib - that's ok
+	}
+	
+	// Implement Numeric for Float
+	try {
+		addTraitImplementation(newState.traitRegistry, 'Numeric', {
+			typeName: 'Float',
+			functions: new Map([
+				['subtract', { kind: 'variable', name: 'primitive_float_subtract', location: builtinLocation }],
+				['multiply', { kind: 'variable', name: 'primitive_float_multiply', location: builtinLocation }],
+				['divide', { kind: 'variable', name: 'primitive_float_divide', location: builtinLocation }]
+			])
+		});
+	} catch (e) {
+		// Implementation may already exist from stdlib - that's ok
+	}
 	
 	return newState;
 };


### PR DESCRIPTION
Add missing runtime trait implementations for `Float` (Numeric, Add) and `String` (Add) to enable proper evaluation of built-in operations.

Previously, only type-level constraint checking for these traits was handled, leading to a "chicken-and-egg" problem where runtime evaluation failed due to the absence of registered trait implementations. This change registers the necessary implementations, connecting primitive functions to the trait system for runtime use without introducing circular dependencies.

---

[Open in Web](https://cursor.com/agents?id=bc-77784610-457e-4f3b-b38a-6d38eb59bcf3) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-77784610-457e-4f3b-b38a-6d38eb59bcf3) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)