### PR TITLE
Implement destructuring with tdd

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -131,6 +131,8 @@ export type Expression =
 	| BinaryExpression
 	| IfExpression
 	| DefinitionExpression
+	| TupleDestructuringExpression
+	| RecordDestructuringExpression
 	| MutableDefinitionExpression
 	| MutationExpression
 	| ImportExpression
@@ -228,6 +230,22 @@ export interface DefinitionExpression {
 	location: Location;
 }
 
+export interface TupleDestructuringExpression {
+	kind: 'tuple-destructuring';
+	pattern: TupleDestructuringPattern;
+	value: Expression;
+	type?: Type;
+	location: Location;
+}
+
+export interface RecordDestructuringExpression {
+	kind: 'record-destructuring';
+	pattern: RecordDestructuringPattern;
+	value: Expression;
+	type?: Type;
+	location: Location;
+}
+
 export interface MutableDefinitionExpression {
 	kind: 'mutable-definition';
 	name: string;
@@ -316,7 +334,7 @@ export interface ListExpression {
 export interface WhereExpression {
 	kind: 'where';
 	main: Expression;
-	definitions: (DefinitionExpression | MutableDefinitionExpression)[];
+	definitions: (DefinitionExpression | TupleDestructuringExpression | RecordDestructuringExpression | MutableDefinitionExpression)[];
 	type?: Type;
 	location: Location;
 }
@@ -353,6 +371,30 @@ export interface RecordPatternField {
 	pattern: Pattern;
 	location: Location;
 }
+
+// Destructuring patterns (different from match patterns)
+export type TupleDestructuringPattern = {
+	kind: 'tuple-destructuring-pattern';
+	elements: DestructuringElement[];
+	location: Location;
+};
+
+export type RecordDestructuringPattern = {
+	kind: 'record-destructuring-pattern';
+	fields: RecordDestructuringField[];
+	location: Location;
+};
+
+export type DestructuringElement = 
+	| { kind: 'variable'; name: string; location: Location }
+	| { kind: 'nested-tuple'; pattern: TupleDestructuringPattern; location: Location }
+	| { kind: 'nested-record'; pattern: RecordDestructuringPattern; location: Location };
+
+export type RecordDestructuringField = 
+	| { kind: 'shorthand'; fieldName: string; location: Location }  // {@name} -> name
+	| { kind: 'rename'; fieldName: string; localName: string; location: Location }  // {@name userName} -> userName
+	| { kind: 'nested-tuple'; fieldName: string; pattern: TupleDestructuringPattern; location: Location }  // {@coords {x, y}}
+	| { kind: 'nested-record'; fieldName: string; pattern: RecordDestructuringPattern; location: Location }; // {@user {@name}}
 
 // Pattern matching case
 export interface MatchCase {

--- a/src/typer/expression-dispatcher.ts
+++ b/src/typer/expression-dispatcher.ts
@@ -12,6 +12,8 @@ import {
 	typeTuple,
 	typeAccessor,
 	typeDefinition,
+	typeTupleDestructuring,
+	typeRecordDestructuring,
 	typeMutableDefinition,
 	typeMutation,
 	typeConstraintDefinition,
@@ -60,6 +62,12 @@ export const typeExpression = (
 
 		case 'definition':
 			return typeDefinition(expr, state);
+
+		case 'tuple-destructuring':
+			return typeTupleDestructuring(expr, state);
+
+		case 'record-destructuring':
+			return typeRecordDestructuring(expr, state);
 
 		case 'mutable-definition':
 			return typeMutableDefinition(expr, state);

--- a/test/language-features/destructuring.test.ts
+++ b/test/language-features/destructuring.test.ts
@@ -1,0 +1,65 @@
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+import { Evaluator, Value } from '../../src/evaluator/evaluator';
+import { parse } from '../../src/parser/parser';
+import { Lexer } from '../../src/lexer/lexer';
+
+function unwrapValue(val: Value): any {
+	if (val === null) return null;
+	if (typeof val !== 'object') return val;
+	switch (val.tag) {
+		case 'number':
+			return val.value;
+		case 'string':
+			return val.value;
+		case 'constructor':
+			if (val.name === 'True') return true;
+			if (val.name === 'False') return false;
+			return val;
+		case 'list':
+			return val.values.map(unwrapValue);
+		case 'tuple':
+			return val.values.map(unwrapValue);
+		case 'record': {
+			const obj: any = {};
+			for (const k in val.fields) obj[k] = unwrapValue(val.fields[k]);
+			return obj;
+		}
+		default:
+			return val;
+	}
+}
+
+test('should destructure simple tuple', () => {
+	const source = '{x, y} = {1, 2}; x + y';
+	const lexer = new Lexer(source);
+	const tokens = lexer.tokenize();
+	
+	const parsed = parse(tokens);
+	
+	const evaluator = new Evaluator();
+	const result = evaluator.evaluateProgram(parsed);
+	assert.equal(unwrapValue(result.finalResult), 3);
+});
+
+test('should destructure record with shorthand', () => {
+	const source = '{@name, @age} = {@name "Bob", @age 25}; name + " is " + toString age';
+	const lexer = new Lexer(source);
+	const tokens = lexer.tokenize();
+	
+	const parsed = parse(tokens);
+	
+	const evaluator = new Evaluator();
+	const result = evaluator.evaluateProgram(parsed);
+	assert.equal(unwrapValue(result.finalResult), "Bob is 25");
+});
+
+test('should fail parsing for list destructuring', () => {
+	const source = '[x, y] = [1, 2]';
+	const lexer = new Lexer(source);
+	const tokens = lexer.tokenize();
+	
+	assert.throws(() => parse(tokens), 'Should fail to parse list destructuring');
+});
+
+test.run();


### PR DESCRIPTION
Implement tuple and record destructuring to enhance language expressiveness.

This PR introduces tuple and record destructuring. The implementation required significant parser enhancements, including a lookahead mechanism to disambiguate destructuring patterns (e.g., `{x, y} = ...`) from existing tuple/record literal parsing. Full type inference and runtime evaluation are also included.

---
<a href="https://cursor.com/background-agent?bcId=bc-2e470a70-d045-44de-a52a-459a7d5a3d6c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2e470a70-d045-44de-a52a-459a7d5a3d6c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>