### PR TITLE
Implement and refine destructuring syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ An functional, expression-based, LLM-friendly programming language designed for 
 - **Pipeline operators** (`|>`, `<|`, `|`, `|?`, `$`) for composition
 - **ADTs** - algebraic data types with pattern matching
 - **Records & tuples** - structured data with type safety
+- **Destructuring patterns** - ergonomic data extraction and import spreading
 - **REPL** - interactive development environment
 - **VSCode Language Server** - for intellisense and hover types (WIP)
 - **Syntax Highlighting** - for VSCode and other editors
@@ -127,6 +128,10 @@ add 1 2
 # Where expressions for local definitions
 x + y where (x = 1; y = 2)  # => 3
 
+# Destructuring for clean data extraction
+{x, y} = {10, 20}; x + y  # => 30
+{@name, @age} = {@name "Alice", @age 30}; name  # => "Alice"
+
 # because nesting can get confusing fast noolang includes a few helpful opperators for reducing the need for parens such as the `|` operator:
 2 | add 3 | add 2
 
@@ -204,6 +209,20 @@ result = match data with (
     Some _ => 0;
     None => -1
 )
+
+# Destructuring patterns for data extraction
+{x, y} = {10, 20}
+{@name, @age} = {@name "Bob", @age 25}
+{@name userName, @age} = {@name "Alice", @age 30}  # Renaming
+
+# Nested destructuring
+{outer, {inner, rest}} = {1, {2, 3}}
+{@user {@name, @age}} = {@user {@name "Charlie", @age 35}}
+{@coords {x, y}, @metadata {@name author}} = {@coords {5, 10}, @metadata {@name "Dave"}}
+
+# Import spreading with destructuring  
+{@add, @multiply} = import "math_module"
+{@square sq, @cube cb} = import "power_module"  # With renaming
 ```
 
 ## Language Syntax
@@ -529,6 +548,51 @@ mutation_demo = (
   counter
 )
 ```
+
+### Destructuring Patterns
+
+Noolang supports comprehensive destructuring for tuples and records, enabling ergonomic data extraction and import spreading:
+
+```noolang
+# Basic tuple destructuring
+{x, y} = {10, 20}           # x = 10, y = 20
+
+# Basic record destructuring
+{@name, @age} = {@name "Alice", @age 30}  # name = "Alice", age = 30
+
+# Record destructuring with renaming
+{@name userName, @age userAge} = {@name "Bob", @age 25}  # userName = "Bob", userAge = 25
+
+# Nested tuple destructuring
+{outer, {inner, rest}} = {1, {2, 3}}  # outer = 1, inner = 2, rest = 3
+
+# Nested record destructuring
+{@user {@name, @age}} = {@user {@name "Charlie", @age 35}}  # name = "Charlie", age = 35
+
+# Complex mixed patterns
+{@coords {x, y}, @metadata {@name author}} = {
+  @coords {10, 20}, 
+  @metadata {@name "Dave"}
+}  # x = 10, y = 20, author = "Dave"
+
+# Import spreading with destructuring
+{@add, @multiply} = import "math_module"  # Extract functions from module
+{@square sq, @cube cb} = import "power_module"  # Extract with renaming
+
+# Works in where expressions
+result where (
+  {x, y} = {5, 10};
+  {@name} = {@name "Test"};
+  result = x + y
+)
+```
+
+**Design Principles:**
+- **Safety First**: Only supports destructuring for statically-known structures
+- **No List Destructuring**: Lists have variable length, making patterns unsafe
+- **Immutable Bindings**: Creates new immutable variable bindings
+- **Type Safety**: Full static analysis and error detection
+- **Clear Syntax**: LLM-friendly and predictable patterns
 
 ### Data Structure Syntax
 
@@ -945,6 +1009,8 @@ match user_result with (
 - ✅ **Tuple patterns**: Full destructuring with literal/variable mixing
 - ✅ **Record patterns**: Partial field matching with nested support
 - ✅ **Mixed patterns**: Constructor + tuple/record pattern combinations
+- ✅ **Destructuring patterns**: Complete tuple and record destructuring with nesting
+- ✅ **Import spreading**: Destructuring imports with renaming support
 
 ### Recursive ADTs
 
@@ -1454,7 +1520,6 @@ Effects are explicit and tracked in the type system:
 ## Future Features
 
 - **Enhanced type annotations**: Record type syntax
-- **Destructuring patterns**: Pattern-based assignment
 - **JavaScript compilation**: Compile to JavaScript
 - **VSCode Language Server**: LSP integration
 

--- a/src/evaluator/evaluator.ts
+++ b/src/evaluator/evaluator.ts
@@ -1931,6 +1931,10 @@ export class Evaluator {
 				} else if (def.kind === 'mutable-definition') {
 					const value = this.evaluateExpression(def.value);
 					this.environment.set(def.name, createCell(value));
+				} else if (def.kind === 'tuple-destructuring') {
+					this.evaluateTupleDestructuring(def);
+				} else if (def.kind === 'record-destructuring') {
+					this.evaluateRecordDestructuring(def);
 				}
 			}
 			// Evaluate the main expression

--- a/src/evaluator/evaluator.ts
+++ b/src/evaluator/evaluator.ts
@@ -13,6 +13,8 @@ import type {
 	DefinitionExpression,
 	TupleDestructuringExpression,
 	RecordDestructuringExpression,
+	TupleDestructuringPattern,
+	RecordDestructuringPattern,
 	ImportExpression,
 	RecordExpression,
 	AccessorExpression,
@@ -1015,13 +1017,96 @@ export class Evaluator {
 
 			if (element.kind === 'variable') {
 				this.environment.set(element.name, elementValue);
+			} else if (element.kind === 'nested-tuple') {
+				// Handle nested tuple destructuring
+				if (elementValue.tag !== 'tuple') {
+					throw new Error(`Expected tuple value for nested tuple destructuring at position ${i}, got ${elementValue.tag}`);
+				}
+				
+				this.extractTupleElements(element.pattern, elementValue);
+			} else if (element.kind === 'nested-record') {
+				// Handle nested record destructuring
+				if (elementValue.tag !== 'record') {
+					throw new Error(`Expected record value for nested record destructuring at position ${i}, got ${elementValue.tag}`);
+				}
+				
+				this.extractRecordFields(element.pattern, elementValue);
 			} else {
-				// TODO: Handle nested destructuring
-				throw new Error('Nested tuple destructuring not yet implemented');
+				throw new Error(`Unknown destructuring element kind: ${(element as any).kind}`);
 			}
 		}
 
 		return value;
+	}
+
+	private extractTupleElements(pattern: TupleDestructuringPattern, tupleValue: any): void {
+		// Check that the number of pattern elements matches tuple elements
+		if (pattern.elements.length !== tupleValue.values.length) {
+			throw new Error(
+				`Nested tuple destructuring length mismatch: pattern has ${pattern.elements.length} elements but value has ${tupleValue.values.length}`
+			);
+		}
+
+		// Bind each pattern element to its corresponding value
+		for (let i = 0; i < pattern.elements.length; i++) {
+			const element = pattern.elements[i];
+			const elementValue = tupleValue.values[i];
+
+			if (element.kind === 'variable') {
+				this.environment.set(element.name, elementValue);
+			} else if (element.kind === 'nested-tuple') {
+				if (elementValue.tag !== 'tuple') {
+					throw new Error(`Expected tuple value for nested tuple destructuring at position ${i}, got ${elementValue.tag}`);
+				}
+				this.extractTupleElements(element.pattern, elementValue);
+			} else if (element.kind === 'nested-record') {
+				if (elementValue.tag !== 'record') {
+					throw new Error(`Expected record value for nested record destructuring at position ${i}, got ${elementValue.tag}`);
+				}
+				this.extractRecordFields(element.pattern, elementValue);
+			} else {
+				throw new Error(`Unknown destructuring element kind: ${(element as any).kind}`);
+			}
+		}
+	}
+
+	private extractRecordFields(pattern: RecordDestructuringPattern, recordValue: any): void {
+		// Bind each pattern field to its corresponding value
+		for (const field of pattern.fields) {
+			if (field.kind === 'shorthand') {
+				// @name -> name
+				if (!(field.fieldName in recordValue.fields)) {
+					throw new Error(`Field '${field.fieldName}' not found in record`);
+				}
+				this.environment.set(field.fieldName, recordValue.fields[field.fieldName]);
+			} else if (field.kind === 'rename') {
+				// @name userName -> userName
+				if (!(field.fieldName in recordValue.fields)) {
+					throw new Error(`Field '${field.fieldName}' not found in record`);
+				}
+				this.environment.set(field.localName, recordValue.fields[field.fieldName]);
+			} else if (field.kind === 'nested-tuple') {
+				if (!(field.fieldName in recordValue.fields)) {
+					throw new Error(`Field '${field.fieldName}' not found in record`);
+				}
+				const fieldValue = recordValue.fields[field.fieldName];
+				if (fieldValue.tag !== 'tuple') {
+					throw new Error(`Expected tuple value for nested tuple destructuring in field '${field.fieldName}', got ${fieldValue.tag}`);
+				}
+				this.extractTupleElements(field.pattern, fieldValue);
+			} else if (field.kind === 'nested-record') {
+				if (!(field.fieldName in recordValue.fields)) {
+					throw new Error(`Field '${field.fieldName}' not found in record`);
+				}
+				const fieldValue = recordValue.fields[field.fieldName];
+				if (fieldValue.tag !== 'record') {
+					throw new Error(`Expected record value for nested record destructuring in field '${field.fieldName}', got ${fieldValue.tag}`);
+				}
+				this.extractRecordFields(field.pattern, fieldValue);
+			} else {
+				throw new Error(`Unknown record destructuring field kind: ${(field as any).kind}`);
+			}
+		}
 	}
 
 	private evaluateRecordDestructuring(
@@ -1035,25 +1120,8 @@ export class Evaluator {
 			throw new Error('Expected record value for record destructuring');
 		}
 
-		// Bind each pattern field to its corresponding value
-		for (const field of expr.pattern.fields) {
-			if (field.kind === 'shorthand') {
-				// @name -> name
-				if (!(field.fieldName in value.fields)) {
-					throw new Error(`Field '${field.fieldName}' not found in record`);
-				}
-				this.environment.set(field.fieldName, value.fields[field.fieldName]);
-			} else if (field.kind === 'rename') {
-				// @name userName -> userName
-				if (!(field.fieldName in value.fields)) {
-					throw new Error(`Field '${field.fieldName}' not found in record`);
-				}
-				this.environment.set(field.localName, value.fields[field.fieldName]);
-			} else {
-				// TODO: Handle nested destructuring
-				throw new Error('Nested record destructuring not yet implemented');
-			}
-		}
+		// Use the helper method to extract fields
+		this.extractRecordFields(expr.pattern, value);
 
 		return value;
 	}

--- a/src/typer/expression-dispatcher.ts
+++ b/src/typer/expression-dispatcher.ts
@@ -21,6 +21,7 @@ import {
 	typeTyped,
 	typeConstrained,
 	typeWhere,
+	typeImport,
 } from './type-inference';
 import { typeApplication, typePipeline } from './function-application';
 import { typeMatch, typeTypeDefinition } from './pattern-matching';
@@ -75,6 +76,9 @@ export const typeExpression = (
 
 		case 'mutation':
 			return typeMutation(expr, state);
+
+		case 'import':
+			return typeImport(expr, state);
 
 		case 'unit':
 			// {} should be polymorphic - it can unify with unit, empty tuples, and empty records

--- a/src/typer/type-inference.ts
+++ b/src/typer/type-inference.ts
@@ -1270,6 +1270,14 @@ export const typeWhere = (
 				quantifiedVars: [],
 			});
 			currentState = { ...currentState, environment: whereEnv };
+		} else if ((def as TupleDestructuringExpression).kind === 'tuple-destructuring') {
+			const tupleResult = typeTupleDestructuring(def as TupleDestructuringExpression, currentState);
+			currentState = tupleResult.state;
+			whereEnv = currentState.environment;
+		} else if ((def as RecordDestructuringExpression).kind === 'record-destructuring') {
+			const recordResult = typeRecordDestructuring(def as RecordDestructuringExpression, currentState);
+			currentState = recordResult.state;
+			whereEnv = currentState.environment;
 		}
 	}
 

--- a/test/language-features/destructuring.test.ts
+++ b/test/language-features/destructuring.test.ts
@@ -104,12 +104,12 @@ test('should throw error for missing fields in record destructuring', () => {
 
 test('should throw error for tuple length mismatch', () => {
 	const source = '{x, y, z} = {1, 2}';
-	expect(() => runCode(source)).toThrow('Tuple destructuring length mismatch');
+	expect(() => runCode(source)).toThrow('Tuple length mismatch');
 });
 
 test('should throw error for type mismatch in destructuring', () => {
 	const source = '{x, y} = "not a tuple"';
-	expect(() => runCode(source)).toThrow('Expected tuple value for tuple destructuring');
+	expect(() => runCode(source)).toThrow('Cannot unify types');
 });
 
 test('should work in where expressions', () => {

--- a/test/language-features/destructuring.test.ts
+++ b/test/language-features/destructuring.test.ts
@@ -16,3 +16,109 @@ test('should fail parsing for list destructuring', () => {
 	const source = '[x, y] = [1, 2]';
 	expect(() => runCode(source)).toThrow();
 });
+
+test('should destructure record with renaming', () => {
+	const source =
+		'{@name userName, @age userAge} = {@name "Charlie", @age 35}; userName + " is " + toString userAge';
+	expect(runCode(source).finalValue).toEqual('Charlie is 35');
+});
+
+test('should destructure nested tuples', () => {
+	const source = '{outer, {inner, rest}} = {1, {2, 3}}; outer + inner + rest';
+	expect(runCode(source).finalValue).toEqual(6);
+});
+
+test('should destructure nested records', () => {
+	const source =
+		'{@user {@name, @age}} = {@user {@name "David", @age 40}}; name + " is " + toString age';
+	expect(runCode(source).finalValue).toEqual('David is 40');
+});
+
+test('should destructure complex nested patterns', () => {
+	const source =
+		'{@coords {x, y}, @metadata {@name author}} = {@coords {10, 20}, @metadata {@name "Eve"}}; "Point (" + toString x + ", " + toString y + ") by " + author';
+	expect(runCode(source).finalValue).toEqual('Point (10, 20) by Eve');
+});
+
+test('should destructure multiple levels of nesting', () => {
+	const source =
+		'{@data {@inner {@value}}} = {@data {@inner {@value 42}}}; value * 2';
+	expect(runCode(source).finalValue).toEqual(84);
+});
+
+test('should work with import destructuring', () => {
+	// First create a test module
+	const moduleSource = `
+		add_fn = fn x y => x + y;
+		multiply_fn = fn x y => x * y;
+		{@add add_fn, @multiply multiply_fn}
+	`;
+	
+	// Write the module to a temporary file
+	const fs = require('fs');
+	fs.writeFileSync('temp_test_module.noo', moduleSource);
+	
+	try {
+		const source = '{@add, @multiply} = import "temp_test_module"; add 3 4 + multiply 2 5';
+		expect(runCode(source).finalValue).toEqual(17);
+	} finally {
+		// Clean up
+		fs.unlinkSync('temp_test_module.noo');
+	}
+});
+
+test('should work with import destructuring and renaming', () => {
+	// First create a test module
+	const moduleSource = `
+		square = fn x => x * x;
+		cube = fn x => x * x * x;
+		{@square square, @cube cube}
+	`;
+	
+	// Write the module to a temporary file
+	const fs = require('fs');
+	fs.writeFileSync('temp_test_module2.noo', moduleSource);
+	
+	try {
+		const source = '{@square sq, @cube cb} = import "temp_test_module2"; sq 4 + cb 2';
+		expect(runCode(source).finalValue).toEqual(24);
+	} finally {
+		// Clean up
+		fs.unlinkSync('temp_test_module2.noo');
+	}
+});
+
+test('should handle mixed tuple and record destructuring', () => {
+	const source = `
+		data = {@tuple {1, 2}, @record {@name "Test"}};
+		{@tuple {first, second}, @record {@name text}} = data;
+		toString first + toString second + text
+	`;
+	expect(runCode(source).finalValue).toEqual('12Test');
+});
+
+test('should throw error for missing fields in record destructuring', () => {
+	const source = '{@name, @missing} = {@name "Test"}';
+	expect(() => runCode(source)).toThrow('Field \'missing\' not found in record');
+});
+
+test('should throw error for tuple length mismatch', () => {
+	const source = '{x, y, z} = {1, 2}';
+	expect(() => runCode(source)).toThrow('Tuple destructuring length mismatch');
+});
+
+test('should throw error for type mismatch in destructuring', () => {
+	const source = '{x, y} = "not a tuple"';
+	expect(() => runCode(source)).toThrow('Expected tuple value for tuple destructuring');
+});
+
+test('should work in where expressions', () => {
+	const source = `
+		result where (
+			{x, y} = {10, 20};
+			{@name} = {@name "Test"};
+			result = toString x + toString y + name
+		)
+	`;
+	expect(runCode(source).finalValue).toEqual('1020Test');
+});


### PR DESCRIPTION
Implement nested destructuring for tuples and records, and enable import destructuring to complete the destructuring syntax plan.

This PR fully implements the destructuring syntax as outlined in `docs/TYPE_SYSTEM.md`, including nested patterns for tuples and records, and fixes import destructuring by correctly handling import types in the expression dispatcher.

---
<a href="https://cursor.com/background-agent?bcId=bc-2baad951-9627-43be-8b5c-c41e4497e2e0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2baad951-9627-43be-8b5c-c41e4497e2e0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>