### PR TITLE
Implement optional accessors for unknown ffi policy

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -334,6 +334,7 @@ export interface FieldExpression {
 export interface AccessorExpression {
 	kind: 'accessor';
 	field: string;
+	optional?: boolean;
 	type?: Type;
 	location: Location;
 }

--- a/src/evaluator/evaluator.ts
+++ b/src/evaluator/evaluator.ts
@@ -1909,7 +1909,7 @@ export class Evaluator {
 
 	private evaluateAccessor(expr: AccessorExpression): Value {
 		// Return a function that takes a record and returns the field value
-		return createNativeFunction(`@${expr.field}`, (record: Value): Value => {
+		return createNativeFunction(`@${expr.field}${expr.optional ? '?' : ''}`, (record: Value): Value => {
 			if (isRecord(record)) {
 				const field = expr.field;
 				const fieldWithAt = `@${field}`;
@@ -1920,6 +1920,10 @@ export class Evaluator {
 				} else if (field in record.fields) {
 					return record.fields[field];
 				}
+			}
+			if (expr.optional) {
+				// None constructor when not found
+				return createConstructor('None', []);
 			}
 			throw new Error(`Field '${expr.field}' not found in record`);
 		});
@@ -2090,7 +2094,7 @@ export class Evaluator {
 					)
 					.join(', ')} }`;
 			case 'accessor':
-				return `@${expr.field}`;
+				return `@${expr.field}${expr.optional ? '?' : ''}`;
 			case 'where':
 				return `${this.expressionToString(expr.main)} where (${expr.definitions
 					.map(d => this.expressionToString(d))

--- a/src/lexer/__tests__/lexer.test.ts
+++ b/src/lexer/__tests__/lexer.test.ts
@@ -262,6 +262,14 @@ test('Lexer - Accessors - should handle @ followed by non-identifier', () => {
 	]);
 });
 
+test('Lexer - Accessors - should tokenize optional accessor', () => {
+	const tokens = getTokenValues('@field?');
+	expect(tokens).toEqual([
+		{ type: 'ACCESSOR', value: 'field?' },
+		{ type: 'EOF', value: '' },
+	]);
+});
+
 test('Lexer - Comments - should skip single-line comments', () => {
 	const codeWithComments = `
 		# this is a comment

--- a/src/lexer/lexer.ts
+++ b/src/lexer/lexer.ts
@@ -256,6 +256,12 @@ export class Lexer {
 			field += this.advance();
 		}
 
+		// Optional accessor suffix '?'
+		if (!this.isEOF() && this.peek() === '?') {
+			this.advance();
+			field += '?';
+		}
+
 		return {
 			type: 'ACCESSOR',
 			value: field,

--- a/src/parser/__tests__/parser-core.test.ts
+++ b/src/parser/__tests__/parser-core.test.ts
@@ -199,6 +199,17 @@ test('Parser - should parse accessor', () => {
 	expect(accessor.field).toBe('name');
 });
 
+test('Parser - should parse optional accessor', () => {
+	const lexer = new Lexer('@name?');
+	const tokens = lexer.tokenize();
+	const program = parse(tokens);
+	expect(program.statements.length).toBe(1);
+	const accessor = program.statements[0];
+	assertAccessorExpression(accessor);
+	expect(accessor.field).toBe('name');
+	expect(accessor.optional).toBe(true);
+});
+
 test('Parser - should parse function with unit parameter', () => {
 	const lexer = new Lexer('fn {} => 42');
 	const tokens = lexer.tokenize();

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -650,7 +650,8 @@ const parseAccessor = C.map(
 	C.accessor(),
 	(token): AccessorExpression => ({
 		kind: 'accessor',
-		field: token.value,
+		field: token.value.endsWith('?') ? token.value.slice(0, -1) : token.value,
+		optional: token.value.endsWith('?'),
 		location: token.location,
 	})
 );
@@ -658,7 +659,7 @@ const parseAccessor = C.map(
 // --- Record Parsing ---
 const parseRecordFieldName = C.map(
 	C.accessor(),
-	token => token.value // Just get the field name without @
+	token => token.value.endsWith('?') ? token.value.slice(0, -1) : token.value // Just get the field name without @ and without optional marker
 );
 
 // Parse an expression that stops at @ (accessor tokens) or semicolon

--- a/src/typer/__tests__/typer.test.ts
+++ b/src/typer/__tests__/typer.test.ts
@@ -254,3 +254,13 @@ test('Constraint Propagation (Functional Typer) - should allow composition when 
 	// head now returns Option List Float instead of List Float
 	expect(typeStr).toBe('Option List Float');
 });
+
+test('Typer - optional accessor returns Option type', () => {
+	const code = `
+	  get = @name?;
+	`;
+	const result = parseAndType(code);
+	const typeStr = typeToString(result.type, result.state.substitution);
+	// Expect something like "{ @name a } -> Option a" (display may vary but should include Option)
+	expect(typeStr.includes('Option')).toBe(true);
+});

--- a/src/typer/type-inference.ts
+++ b/src/typer/type-inference.ts
@@ -1240,19 +1240,27 @@ export const typeAccessor = (
 ): TypeResult => {
 	// Check cache first
 	const fieldName = expr.field;
-	const cachedType = state.accessorCache.get(fieldName);
+	const cacheKey = expr.optional ? `${fieldName}?` : fieldName;
+	const cachedType = state.accessorCache.get(cacheKey);
 	if (cachedType) {
 		return createPureTypeResult(cachedType, state);
 	}
 
 	// Accessors return functions that take any record with the required field and return the field type
 	// @bar should have type {bar: a, ...} -> a (allows extra fields)
+	// @bar? should have type {bar: a, ...} -> Option a
 	// Use a fresh type variable for the field type
 	const [fieldType, nextState] = freshTypeVariable(state);
 	// Create a simple type variable for the record (no constraints on the variable itself)
 	const [recordVar, finalState] = freshTypeVariable(nextState);
+
+	// If optional, wrap return type in Option
+	const returnType = expr.optional
+		? variantType('Option', [fieldType])
+		: fieldType;
+
 	// Create a function type with constraints attached to both places
-	const funcType = functionType([recordVar], fieldType);
+	const funcType = functionType([recordVar], returnType);
 	// Add the constraint to both the parameter type variable (for validation)
 	// and the function type (for display)
 	if (recordVar.kind === 'variable') {
@@ -1271,10 +1279,10 @@ export const typeAccessor = (
 		];
 	}
 
-	// Cache the result for future use
+	// Cache the result for future use (keyed by optional flag)
 	const resultState = {
 		...finalState,
-		accessorCache: new Map(finalState.accessorCache).set(fieldName, funcType),
+		accessorCache: new Map(finalState.accessorCache).set(cacheKey, funcType),
 	};
 
 	return createPureTypeResult(funcType, resultState);


### PR DESCRIPTION
Implement optional accessors (`@key?`) to allow safe access to potentially missing record fields, returning an `Option` type.

---
<a href="https://cursor.com/background-agent?bcId=bc-b37d4aed-42d2-4785-8b7d-17cc1f665c97">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b37d4aed-42d2-4785-8b7d-17cc1f665c97">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

