### PR TITLE
Fix trait-function constraint resolution through the `|` (thrush) operator

### DIFF
--- a/src/typer/type-inference.ts
+++ b/src/typer/type-inference.ts
@@ -828,36 +828,24 @@ export const typeIf = (expr: IfExpression, state: TypeState): TypeResult => {
 };
 
 
-const handleThrush = (
-	expr: BinaryExpression,
-	leftResult: TypeResult,
-	rightResult: TypeResult,
-	state: TypeState
-): TypeResult => {
-	if (
-		rightResult.type.kind !== 'function' ||
-		rightResult.type.params.length < 1
-	)
-		throwTypeError(
-			location => nonFunctionApplicationError(rightResult.type, location),
-			getExprLocation(expr)
-		);
-	const constraintContext = rightResult.type.constraints || [];
-	const newState = unify(
-		rightResult.type.params[0],
-		leftResult.type,
-		state,
-		getExprLocation(expr),
-		{ constraintContext }
+// Thrush `a | f` is equivalent to the application `f a`. Delegating to
+// typeApplication (rather than a bespoke unify) reuses the full constraint
+// resolution machinery, so trait-constrained functions like `map` resolve
+// their higher-kinded variable (e.g. Functor `c` -> `List`) instead of leaking
+// a free `c Float`. That leak previously broke chains such as
+// `[1,2,3] | map show | join ", "`.
+const handleThrush = (expr: BinaryExpression, state: TypeState): TypeResult =>
+	typeApplication(
+		{
+			kind: 'application',
+			func: expr.right,
+			args: [expr.left],
+			location: expr.location,
+		},
+		state
 	);
-	return createTypeResult(
-		rightResult.type.return,
-		unionEffects(leftResult.effects, rightResult.effects),
-		newState
-	);
-};
 
-const handleDollar = (expr: BinaryExpression, state: TypeState): TypeResult => 
+const handleDollar = (expr: BinaryExpression, state: TypeState): TypeResult =>
 	typeApplication({ kind: 'application', func: expr.left, args: [expr.right], location: expr.location }, state);
 
 const handleSafeThrush = (
@@ -967,8 +955,7 @@ export const typeBinary = (
 	currentState = rightResult.state;
 
 	// Special operators
-	if (expr.operator === '|')
-		return handleThrush(expr, leftResult, rightResult, currentState);
+	if (expr.operator === '|') return handleThrush(expr, currentState);
 	if (expr.operator === '$') return handleDollar(expr, currentState);
 
 	if (expr.operator === '|?')

--- a/test/pipe-trait-functions.test.ts
+++ b/test/pipe-trait-functions.test.ts
@@ -63,24 +63,33 @@ describe('Pipe operator with trait functions', () => {
 		expect(result.finalType).toBe('List Float');
 	});
 
-	// TODO: These should work when pipe operator is fixed for multi-argument trait functions
-	test.skip('pipe with map should work like this', () => {
+	test('pipe with map resolves the Functor constructor to List', () => {
 		const code = `[1, 2, 3] | map (fn x => x * 2)`;
-		
+
 		const result = runCode(code);
 		expect(result.finalValue).toEqual([2, 4, 6]);
 		expect(result.finalType).toBe('List Float');
 	});
 
-	test.skip('chained pipes with trait functions should work like this', () => {
+	test('chained pipes with trait functions keep resolving the constructor', () => {
 		const code = `
-		[1, 2, 3] 
+		[1, 2, 3]
 		| map (fn x => x * 2)
 		| map (fn x => x + 1)
 		`;
-		
+
 		const result = runCode(code);
 		expect(result.finalValue).toEqual([3, 5, 7]);
 		expect(result.finalType).toBe('List Float');
+	});
+
+	test('chaining across different trait functions (map show | join)', () => {
+		// Regression: `map show` must resolve to `List String` (not a free `c String`)
+		// so the following `join` (which needs `List String`) unifies.
+		const code = `[1, 2, 3] | map show | join ", "`;
+
+		const result = runCode(code);
+		expect(result.finalValue).toBe('1, 2, 3');
+		expect(result.finalType).toBe('String');
 	});
 });


### PR DESCRIPTION
## Problem

Piping a value into a trait-constrained function silently produced the wrong **type** (the value was fine). For example:

```
noolang> [1,2,3] | map (fn x => x * 2)
[2, 4, 6] : a Float        # should be : List Float
```

`map` has type `(a -> b) -> c a -> c b given c implements Functor`. When applied directly, `map f [1,2,3]` resolves the Functor constructor `c` to `List` via constraint resolution. But the thrush operator `|` had its own bespoke typing path that only did a plain `unify` of the first parameter and returned `map`'s raw return type — so `c` was never resolved and leaked as a free higher-kinded variable `c Float`.

The value still evaluated correctly (the evaluator doesn't type-check), so this hid until you chained a stage that actually needs the concrete constructor:

```
noolang> [1,2,3] | map show | join ", "
TypeError: Expected List String, Got c String
```

`join` needs `List String`, but `map show` handed it `c String`.

## Fix

`a | f` is exactly the application `f a`, so `handleThrush` now delegates to `typeApplication` — the same way `$` already does. This reuses the full constraint-resolution machinery (`tryResolveConstraints`) that direct application uses, so the Functor constructor resolves to `List` consistently.

The bespoke `unify`-and-return-raw-type path is deleted.

## Result

```
[1,2,3] | map (fn x => x * 2)              : List Float   ✅
[1,2,3] | map (fn x=>x*2) | map (fn x=>x+1): List Float   ✅
[1,2,3] | map show | join ", "             : String  → "1, 2, 3"  ✅
```

## Tests

- Un-skips two stale tests in `pipe-trait-functions.test.ts` — they were fixed-in-value but still failing on the `List Float` type assertion; they now pass on both.
- Adds a regression test for chaining across *different* trait functions (`map show | join`), the case that motivated this.
- Full suite: **982 pass / 0 fail / 12 skip** (was 979/0/14). `tsc --noEmit` clean. No example regressions.

## Out of scope

The remaining `test.skip` in `thrush-constraint-weaknesses.test.ts` (`| operator with trait functions`) is a **different** missing feature — heterogeneous lists `List (Float | String)` — not this bug. Left skipped intentionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
