### PR TITLE
Implement Eq for String

### DIFF
--- a/README.md
+++ b/README.md
@@ -1634,6 +1634,7 @@ show "hello";         # Uses Show String implementation
 show [1, 2, 3];       # Uses Show (List a) implementation with Show Float
 
 equals 1 2;           # Uses Eq Float implementation
+equals "a" "b";       # Uses Eq String implementation
 ```
 
 ### Conditional Implementations

--- a/src/evaluator/evaluator.ts
+++ b/src/evaluator/evaluator.ts
@@ -1072,6 +1072,19 @@ export class Evaluator {
 		);
 
 		this.environment.set(
+			'primitive_string_equals',
+			createNativeFunction(
+				'primitive_string_equals',
+				(a: Value) => (b: Value) => {
+					if (isString(a) && isString(b)) {
+						return createBool(a.value === b.value);
+					}
+					throw new Error('primitive_string_equals requires two strings');
+				}
+			)
+		);
+
+		this.environment.set(
 			'primitive_float_divide',
 			createNativeFunction(
 				'primitive_float_divide',

--- a/src/typer/__tests__/eq-string.test.ts
+++ b/src/typer/__tests__/eq-string.test.ts
@@ -1,0 +1,36 @@
+import { Lexer } from '../../lexer/lexer';
+import { parse } from '../../parser/parser';
+import { typeAndDecorate } from '../index';
+import { Evaluator } from '../../evaluator/evaluator';
+import { test, expect } from 'bun:test';
+import { assertConstructorValue } from '../../../test/utils';
+
+const evaluate = (code: string) => {
+	const program = parse(new Lexer(code).tokenize());
+	const typeResult = typeAndDecorate(program);
+	const evaluator = new Evaluator({
+		traitRegistry: typeResult.state.traitRegistry,
+	});
+	return evaluator.evaluateProgram(program).finalResult;
+};
+
+// Regression: Eq was implemented for Float and Bool but not String, so
+// `equals "a" "b"` failed with "No implementation of trait function equals
+// for String, String".
+test('Eq String - equal strings compare True', () => {
+	const result = evaluate('equals "hello" "hello"');
+	assertConstructorValue(result);
+	expect(result.name).toBe('True');
+});
+
+test('Eq String - different strings compare False', () => {
+	const result = evaluate('equals "hello" "world"');
+	assertConstructorValue(result);
+	expect(result.name).toBe('False');
+});
+
+test('Eq String - empty strings compare True', () => {
+	const result = evaluate('equals "" ""');
+	assertConstructorValue(result);
+	expect(result.name).toBe('True');
+});

--- a/src/typer/builtins.ts
+++ b/src/typer/builtins.ts
@@ -408,6 +408,11 @@ export const initializeBuiltins = (state: TypeState): TypeState => {
 		quantifiedVars: [],
 	});
 
+	newEnv.set('primitive_string_equals', {
+		type: createBinaryFunctionType(stringType(), stringType(), boolType()),
+		quantifiedVars: [],
+	});
+
 	// Primitive Subtract trait implementations for type checking
 	newEnv.set('primitive_float_subtract', {
 		type: createBinaryFunctionType(floatType(), floatType(), floatType()),

--- a/stdlib.noo
+++ b/stdlib.noo
@@ -93,6 +93,10 @@ implement Eq Float (
   equals = primitive_float_equals
 );
 
+implement Eq String (
+  equals = primitive_string_equals
+);
+
 # ========================================
 # UTILITY FUNCTIONS
 # ========================================


### PR DESCRIPTION
`Eq` was implemented for `Float` and `Bool` but not `String`, so `equals "a" "b"` (and `==` on strings) failed with:

```
No implementation of trait function equals for String, String
```

This gap surfaced while cleaning up the README (#102).

## Fix
Mirror the `Eq Float` implementation for strings:
- `primitive_string_equals` builtin — type signature (`builtins.ts`) and native implementation comparing string values (`evaluator.ts`).
- `implement Eq String (equals = primitive_string_equals)` in `stdlib.noo`.
- Restore the `equals "a" "b"` example in the README (removed when the gap was found).

## Tests
- New `eq-string.test.ts` with 3 cases (equal, unequal, empty), proven red→green against the pre-fix code.
- Full suite: **996 pass / 0 fail**; `tsc` clean; doc-validation passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)