### PR TITLE
Infer function effects and enforce effect annotations

### DIFF
--- a/src/typer/__tests__/effect-inference.test.ts
+++ b/src/typer/__tests__/effect-inference.test.ts
@@ -1,0 +1,53 @@
+import { Lexer } from '../../lexer/lexer';
+import { parse } from '../../parser/parser';
+import { typeAndDecorate } from '../index';
+import { typeToString } from '../helpers';
+import { test, expect } from 'bun:test';
+import { parseAndType } from '../../../test/utils';
+
+const typeStr = (code: string) => {
+	const r = parseAndType(code);
+	return typeToString(r.type, r.state.substitution);
+};
+
+const typeChecks = (code: string) => typeAndDecorate(parse(new Lexer(code).tokenize()));
+
+// --- Effect inference: a function's body effects are latent on its type ---
+
+test('Effect inference - fn x => print x carries !write on its type', () => {
+	expect(typeStr('fn x => print x')).toBe('a -> a !write');
+});
+
+test('Effect inference - a pure function has no effect', () => {
+	expect(typeStr('fn x => x')).toBe('a -> a');
+});
+
+test('Effect inference - readFile body surfaces !read', () => {
+	expect(typeStr('fn p => readFile p')).toBe('String -> String !read');
+});
+
+test('Effect inference - effects propagate through a wrapping call', () => {
+	expect(typeStr('g = fn x => print x; fn y => g y')).toBe('a -> a !write');
+});
+
+// --- Effect enforcement: annotations may over-declare but not omit effects ---
+
+test('Effect enforcement - annotation omitting a performed effect is rejected', () => {
+	expect(() => typeChecks('fn x => print x : a -> a')).toThrow(
+		/omits effect .*write/
+	);
+});
+
+test('Effect enforcement - annotation omitting one of several effects is rejected', () => {
+	expect(() =>
+		typeChecks('fn n => (log "x"; print n) : Float -> Float !write')
+	).toThrow(/omits effect .*log/);
+});
+
+test('Effect enforcement - a matching effect annotation is accepted', () => {
+	expect(typeStr('fn x => print x : a -> a !write')).toBe('a -> a !write');
+});
+
+test('Effect enforcement - over-declaring effects (conservative) is allowed', () => {
+	expect(typeStr('fn x => x : a -> a !write')).toBe('a -> a !write');
+});

--- a/src/typer/type-inference.ts
+++ b/src/typer/type-inference.ts
@@ -31,6 +31,7 @@ import {
 	type Type,
 	type FunctionType,
 	type Constraint,
+	type Effect,
 	type RecordDestructuringField,
 	floatType,
 	stringType,
@@ -53,6 +54,7 @@ import {
 	undefinedVariableError,
 	nonFunctionApplicationError,
 	traitFunctionShadowingError,
+	createTypeError,
 } from './type-errors';
 import {
 	getExprLocation,
@@ -519,10 +521,15 @@ function buildNormalFunctionType(
 		bodyType = bodyType.baseType;
 	}
 
-	// Build the function type normally
+	// Build the function type normally. The body's effects are latent: they are
+	// performed when the function is fully applied, so they belong on the
+	// innermost arrow (the last parameter, whose application returns the body),
+	// not on the definition itself.
 	let funcType = bodyType;
 	for (let i = paramTypes.length - 1; i >= 0; i--) {
-		funcType = functionType([paramTypes[i]], funcType);
+		const effects =
+			i === paramTypes.length - 1 ? bodyResult.effects : emptyEffects();
+		funcType = functionType([paramTypes[i]], funcType, effects);
 	}
 
 	// Combine implicit constraints with body constraints
@@ -576,6 +583,11 @@ export const typeFunction = (
 					implicitConstraints
 				);
 
+	// The latent effects now live on the function type (see
+	// buildNormalFunctionType) so they fire on application and show in the
+	// inferred type. They are also surfaced here as a conservative whole-program
+	// over-approximation (higher-order effect propagation is not yet tracked via
+	// effect variables).
 	return createTypeResult(funcType, bodyResult.effects, currentState);
 };
 
@@ -1492,12 +1504,23 @@ const resolveTypeAliases = (
 	}
 };
 
+// Collect the latent effects along a (possibly curried) function type's spine.
+const collectSpineEffects = (type: Type): Set<Effect> => {
+	const effects = new Set<Effect>();
+	let t: Type = type;
+	while (t.kind === 'function') {
+		if (t.effects) for (const e of t.effects) effects.add(e);
+		t = t.return;
+	}
+	return effects;
+};
+
 export const typeTyped = (
 	expr: TypedExpression,
 	state: TypeState
 ): TypeResult => {
-	// For typed expressions, trust the explicit type annotation completely
-	// This preserves the exact type annotation as written by the user
+	// For typed expressions, trust the explicit type annotation's structure but
+	// still validate that it does not hide effects performed by the expression.
 
 	// Infer the expression to get effects only
 	const inferredResult = typeExpression(expr.expression, state);
@@ -1512,6 +1535,28 @@ export const typeTyped = (
 		inferredResult.state,
 		getExprLocation(expr)
 	);
+
+	// Effect enforcement: a function annotation may over-declare effects (a
+	// conservative claim) but must not omit an effect the body performs.
+	const inferredType = substitute(inferredResult.type, currentState.substitution);
+	if (inferredType.kind === 'function' && resolvedType.kind === 'function') {
+		const performed = collectSpineEffects(inferredType);
+		const declared = collectSpineEffects(resolvedType);
+		const omitted = [...performed].filter(e => !declared.has(e));
+		if (omitted.length > 0) {
+			throwTypeError(
+				location =>
+					createTypeError(
+						`Type annotation omits effect${omitted.length > 1 ? 's' : ''} !${omitted.join(
+							' !'
+						)} performed by the expression`,
+						{},
+						location
+					),
+				getExprLocation(expr)
+			);
+		}
+	}
 
 	// Return the resolved type (which preserves the annotation structure exactly)
 	return createTypeResult(resolvedType, inferredResult.effects, currentState);


### PR DESCRIPTION
The effect system tracked effects on builtins and unioned them at application, but **function definitions dropped their body effects from the function type** — so effect inference and annotation checking were effectively non-functional:

```
fn x => print x            # was: a -> a        now: a -> a !write
fn x => print x : a -> a   # was: accepted (!), silently laundering the effect
```

## Changes
1. **Effect inference** — `buildNormalFunctionType` now attaches the body's effects to the innermost arrow (effects are latent; they fire when the function is fully applied). Application already unions a function type's effects, so effects now propagate through first-order calls (`g = fn x => print x; fn y => g y` → `a -> a !write`). The definition still surfaces body effects as a conservative whole-program over-approximation, so nothing regresses.
2. **Effect enforcement** — `typeTyped` now checks effect annotations: a function annotation may *over-declare* effects (a conservative claim) but must not *omit* an effect the body performs. Omitting one is rejected with `Type annotation omits effect !X performed by the expression`.

## Known follow-up (not in this PR)
Higher-order effect propagation (e.g. `compose`/`map`/`reduce` over effectful functions) still relies on the coarse whole-program over-approximation rather than true **effect polymorphism** (effect variables on function types). That's the natural next step for the effect system.

## Tests
- New `effect-inference.test.ts` (8 cases: inference + enforcement), proven red→green (5 fail without the change).
- Full suite: **1008 pass / 0 fail**; `tsc` clean; `validate_examples.js` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)