### PR TITLE
Add Eq for Option/Result/List and polymorphic ordering

### DIFF
--- a/src/evaluator/evaluator.ts
+++ b/src/evaluator/evaluator.ts
@@ -266,6 +266,7 @@ export class Evaluator {
 			'<',
 			createNativeFunction('<', (a: Value) => (b: Value) => {
 				if (isNumber(a) && isNumber(b)) return createBool(a.value < b.value);
+				if (isString(a) && isString(b)) return createBool(a.value < b.value);
 				throw new Error(`Cannot compare ${typeof a} and ${typeof b}`);
 			})
 		);
@@ -273,6 +274,7 @@ export class Evaluator {
 			'>',
 			createNativeFunction('>', (a: Value) => (b: Value) => {
 				if (isNumber(a) && isNumber(b)) return createBool(a.value > b.value);
+				if (isString(a) && isString(b)) return createBool(a.value > b.value);
 				throw new Error(`Cannot compare ${typeof a} and ${typeof b}`);
 			})
 		);
@@ -280,6 +282,7 @@ export class Evaluator {
 			'<=',
 			createNativeFunction('<=', (a: Value) => (b: Value) => {
 				if (isNumber(a) && isNumber(b)) return createBool(a.value <= b.value);
+				if (isString(a) && isString(b)) return createBool(a.value <= b.value);
 				throw new Error(`Cannot compare ${typeof a} and ${typeof b}`);
 			})
 		);
@@ -287,6 +290,7 @@ export class Evaluator {
 			'>=',
 			createNativeFunction('>=', (a: Value) => (b: Value) => {
 				if (isNumber(a) && isNumber(b)) return createBool(a.value >= b.value);
+				if (isString(a) && isString(b)) return createBool(a.value >= b.value);
 				throw new Error(`Cannot compare ${typeof a} and ${typeof b}`);
 			})
 		);
@@ -1080,6 +1084,101 @@ export class Evaluator {
 						return createBool(a.value === b.value);
 					}
 					throw new Error('primitive_string_equals requires two strings');
+				}
+			)
+		);
+
+		this.environment.set(
+			'primitive_string_less_than',
+			createNativeFunction(
+				'primitive_string_less_than',
+				(a: Value) => (b: Value) => {
+					if (isString(a) && isString(b)) {
+						return createBool(a.value < b.value);
+					}
+					throw new Error('primitive_string_less_than requires two strings');
+				}
+			)
+		);
+
+		this.environment.set(
+			'primitive_string_greater_than',
+			createNativeFunction(
+				'primitive_string_greater_than',
+				(a: Value) => (b: Value) => {
+					if (isString(a) && isString(b)) {
+						return createBool(a.value > b.value);
+					}
+					throw new Error('primitive_string_greater_than requires two strings');
+				}
+			)
+		);
+
+		this.environment.set(
+			'primitive_string_less_than_or_equal',
+			createNativeFunction(
+				'primitive_string_less_than_or_equal',
+				(a: Value) => (b: Value) => {
+					if (isString(a) && isString(b)) {
+						return createBool(a.value <= b.value);
+					}
+					throw new Error('primitive_string_less_than_or_equal requires two strings');
+				}
+			)
+		);
+
+		this.environment.set(
+			'primitive_string_greater_than_or_equal',
+			createNativeFunction(
+				'primitive_string_greater_than_or_equal',
+				(a: Value) => (b: Value) => {
+					if (isString(a) && isString(b)) {
+						return createBool(a.value >= b.value);
+					}
+					throw new Error('primitive_string_greater_than_or_equal requires two strings');
+				}
+			)
+		);
+
+		this.environment.set(
+			'primitive_float_less_than',
+			createNativeFunction(
+				'primitive_float_less_than',
+				(a: Value) => (b: Value) => {
+					if (isNumber(a) && isNumber(b)) {
+						return createBool(a.value < b.value);
+					}
+					throw new Error('primitive_float_less_than requires two numbers');
+				}
+			)
+		);
+
+		this.environment.set(
+			'primitive_list_all2',
+			createNativeFunction(
+				'primitive_list_all2',
+				(pred: Value) => (list1: Value) => (list2: Value) => {
+					if (isList(list1) && isList(list2)) {
+						if (list1.values.length !== list2.values.length) return createBool(false);
+						for (let i = 0; i < list1.values.length; i++) {
+							let result: Value;
+							if (isFunction(pred) || isNativeFunction(pred)) {
+								const partial = applyValueFunction(pred, list1.values[i]);
+								result = applyValueFunction(partial, list2.values[i]);
+							} else if (isTraitFunctionValue(pred)) {
+								result = this.resolveTraitFunctionWithArgs(
+									pred.name,
+									[list1.values[i], list2.values[i]],
+									pred.traitRegistry
+								);
+							} else {
+								throw new Error('primitive_list_all2: predicate must be a function');
+							}
+							if (!isBool(result) || !boolValue(result)) return createBool(false);
+						}
+						return createBool(true);
+					}
+					throw new Error('primitive_list_all2 requires a function and two lists');
 				}
 			)
 		);

--- a/src/typer/__tests__/eq-collections.test.ts
+++ b/src/typer/__tests__/eq-collections.test.ts
@@ -1,0 +1,135 @@
+import { Lexer } from '../../lexer/lexer';
+import { parse } from '../../parser/parser';
+import { typeAndDecorate } from '../index';
+import { Evaluator } from '../../evaluator/evaluator';
+import { test, expect } from 'bun:test';
+import { assertConstructorValue } from '../../../test/utils';
+
+const evaluate = (code: string) => {
+	const program = parse(new Lexer(code).tokenize());
+	const typeResult = typeAndDecorate(program);
+	const evaluator = new Evaluator({
+		traitRegistry: typeResult.state.traitRegistry,
+	});
+	return evaluator.evaluateProgram(program).finalResult;
+};
+
+// ========================================
+// Eq Option
+// ========================================
+
+test('Eq Option - Some equal values compare True', () => {
+	const result = evaluate('equals (Some 1) (Some 1)');
+	assertConstructorValue(result);
+	expect(result.name).toBe('True');
+});
+
+test('Eq Option - Some different values compare False', () => {
+	const result = evaluate('equals (Some 1) (Some 2)');
+	assertConstructorValue(result);
+	expect(result.name).toBe('False');
+});
+
+test('Eq Option - None equals None', () => {
+	const result = evaluate('equals None None');
+	assertConstructorValue(result);
+	expect(result.name).toBe('True');
+});
+
+test('Eq Option - Some vs None compares False', () => {
+	const result = evaluate('equals (Some 1) None');
+	assertConstructorValue(result);
+	expect(result.name).toBe('False');
+});
+
+test('Eq Option - None vs Some compares False', () => {
+	const result = evaluate('equals None (Some 1)');
+	assertConstructorValue(result);
+	expect(result.name).toBe('False');
+});
+
+test('Eq Option - nested Option equality Some(Some)', () => {
+	const result = evaluate('equals (Some (Some 42)) (Some (Some 42))');
+	assertConstructorValue(result);
+	expect(result.name).toBe('True');
+});
+
+// ========================================
+// Eq Result
+// ========================================
+
+test('Eq Result - Ok equal values compare True', () => {
+	const result = evaluate('equals (Ok 1) (Ok 1)');
+	assertConstructorValue(result);
+	expect(result.name).toBe('True');
+});
+
+test('Eq Result - Ok different values compare False', () => {
+	const result = evaluate('equals (Ok 1) (Ok 2)');
+	assertConstructorValue(result);
+	expect(result.name).toBe('False');
+});
+
+test('Eq Result - Err equal values compare True', () => {
+	const result = evaluate('equals (Err "oops") (Err "oops")');
+	assertConstructorValue(result);
+	expect(result.name).toBe('True');
+});
+
+test('Eq Result - Err different values compare False', () => {
+	const result = evaluate('equals (Err "a") (Err "b")');
+	assertConstructorValue(result);
+	expect(result.name).toBe('False');
+});
+
+test('Eq Result - Ok vs Err compares False', () => {
+	const result = evaluate('equals (Ok 1) (Err "oops")');
+	assertConstructorValue(result);
+	expect(result.name).toBe('False');
+});
+
+test('Eq Result - Err vs Ok compares False', () => {
+	const result = evaluate('equals (Err "oops") (Ok 1)');
+	assertConstructorValue(result);
+	expect(result.name).toBe('False');
+});
+
+// ========================================
+// Eq List
+// ========================================
+
+test('Eq List - equal lists compare True', () => {
+	const result = evaluate('equals [1, 2, 3] [1, 2, 3]');
+	assertConstructorValue(result);
+	expect(result.name).toBe('True');
+});
+
+test('Eq List - different element compares False', () => {
+	const result = evaluate('equals [1, 2] [1, 3]');
+	assertConstructorValue(result);
+	expect(result.name).toBe('False');
+});
+
+test('Eq List - different length compares False', () => {
+	const result = evaluate('equals [1, 2] [1, 2, 3]');
+	assertConstructorValue(result);
+	expect(result.name).toBe('False');
+});
+
+test('Eq List - empty lists compare True', () => {
+	const result = evaluate('equals [] []');
+	assertConstructorValue(result);
+	expect(result.name).toBe('True');
+});
+
+test('Eq List - empty vs non-empty compares False', () => {
+	const result = evaluate('equals [] [1]');
+	assertConstructorValue(result);
+	expect(result.name).toBe('False');
+});
+
+test('Eq List - string lists compare correctly', () => {
+	const result = evaluate('equals ["a", "b"] ["a", "b"]');
+	assertConstructorValue(result);
+	expect(result.name).toBe('True');
+});

--- a/src/typer/__tests__/ord.test.ts
+++ b/src/typer/__tests__/ord.test.ts
@@ -1,0 +1,123 @@
+import { Lexer } from '../../lexer/lexer';
+import { parse } from '../../parser/parser';
+import { typeAndDecorate } from '../index';
+import { Evaluator } from '../../evaluator/evaluator';
+import { test, expect } from 'bun:test';
+import { assertConstructorValue } from '../../../test/utils';
+
+const evaluate = (code: string) => {
+	const program = parse(new Lexer(code).tokenize());
+	const typeResult = typeAndDecorate(program);
+	const evaluator = new Evaluator({
+		traitRegistry: typeResult.state.traitRegistry,
+	});
+	return evaluator.evaluateProgram(program).finalResult;
+};
+
+// ========================================
+// String comparison operators
+// ========================================
+
+test('Ord String - less than "a" < "b" is True', () => {
+	const result = evaluate('"a" < "b"');
+	assertConstructorValue(result);
+	expect(result.name).toBe('True');
+});
+
+test('Ord String - less than "b" < "a" is False', () => {
+	const result = evaluate('"b" < "a"');
+	assertConstructorValue(result);
+	expect(result.name).toBe('False');
+});
+
+test('Ord String - less than equal strings is False', () => {
+	const result = evaluate('"a" < "a"');
+	assertConstructorValue(result);
+	expect(result.name).toBe('False');
+});
+
+test('Ord String - greater than "b" > "a" is True', () => {
+	const result = evaluate('"b" > "a"');
+	assertConstructorValue(result);
+	expect(result.name).toBe('True');
+});
+
+test('Ord String - greater than "a" > "b" is False', () => {
+	const result = evaluate('"a" > "b"');
+	assertConstructorValue(result);
+	expect(result.name).toBe('False');
+});
+
+test('Ord String - less than or equal "a" <= "a" is True', () => {
+	const result = evaluate('"a" <= "a"');
+	assertConstructorValue(result);
+	expect(result.name).toBe('True');
+});
+
+test('Ord String - less than or equal "a" <= "b" is True', () => {
+	const result = evaluate('"a" <= "b"');
+	assertConstructorValue(result);
+	expect(result.name).toBe('True');
+});
+
+test('Ord String - less than or equal "b" <= "a" is False', () => {
+	const result = evaluate('"b" <= "a"');
+	assertConstructorValue(result);
+	expect(result.name).toBe('False');
+});
+
+test('Ord String - greater than or equal "b" >= "a" is True', () => {
+	const result = evaluate('"b" >= "a"');
+	assertConstructorValue(result);
+	expect(result.name).toBe('True');
+});
+
+test('Ord String - greater than or equal "a" >= "a" is True', () => {
+	const result = evaluate('"a" >= "a"');
+	assertConstructorValue(result);
+	expect(result.name).toBe('True');
+});
+
+test('Ord String - greater than or equal "a" >= "b" is False', () => {
+	const result = evaluate('"a" >= "b"');
+	assertConstructorValue(result);
+	expect(result.name).toBe('False');
+});
+
+test('Ord String - lexicographic comparison "apple" < "banana"', () => {
+	const result = evaluate('"apple" < "banana"');
+	assertConstructorValue(result);
+	expect(result.name).toBe('True');
+});
+
+// ========================================
+// Float comparison still works
+// ========================================
+
+test('Ord Float - 1 < 2 is True', () => {
+	const result = evaluate('1 < 2');
+	assertConstructorValue(result);
+	expect(result.name).toBe('True');
+});
+
+test('Ord Float - 2 > 1 is True', () => {
+	const result = evaluate('2 > 1');
+	assertConstructorValue(result);
+	expect(result.name).toBe('True');
+});
+
+// ========================================
+// Ord trait function less_than on String
+// ========================================
+
+test('Ord String - less_than trait function works on strings', () => {
+	const result = evaluate('less_than "a" "b"');
+	assertConstructorValue(result);
+	expect(result.name).toBe('True');
+});
+
+test('Ord Float - less_than trait function works on floats', () => {
+	const result = evaluate('less_than 1 2');
+	assertConstructorValue(result);
+	expect(result.name).toBe('True');
+});

--- a/src/typer/__tests__/ord.test.ts
+++ b/src/typer/__tests__/ord.test.ts
@@ -14,6 +14,11 @@ const evaluate = (code: string) => {
 	return evaluator.evaluateProgram(program).finalResult;
 };
 
+const typeCheck = (code: string) => {
+	const program = parse(new Lexer(code).tokenize());
+	return typeAndDecorate(program);
+};
+
 // ========================================
 // String comparison operators
 // ========================================
@@ -120,4 +125,23 @@ test('Ord Float - less_than trait function works on floats', () => {
 	const result = evaluate('less_than 1 2');
 	assertConstructorValue(result);
 	expect(result.name).toBe('True');
+});
+
+// ========================================
+// Ord constraint is enforced at type-check time
+// ========================================
+
+test('Ord - comparing records (no Ord impl) is rejected at type-check', () => {
+	expect(() => typeCheck('{@a 1} < {@a 2}')).toThrow();
+});
+
+test('Ord - comparing a user variant with no Ord impl is rejected at type-check', () => {
+	const code = 'variant Foo = Bar; (Bar) < (Bar)';
+	expect(() => typeCheck(code)).toThrow();
+});
+
+test('Ord - String and Float still type-check under Ord constraint', () => {
+	expect(() => typeCheck('"a" < "b"')).not.toThrow();
+	expect(() => typeCheck('1 < 2')).not.toThrow();
+	expect(() => typeCheck('3.0 <= 4.0')).not.toThrow();
 });

--- a/src/typer/builtins.ts
+++ b/src/typer/builtins.ts
@@ -98,20 +98,41 @@ export const initializeBuiltins = (state: TypeState): TypeState => {
 		type: functionType([typeVariable('a'), typeVariable('a')], boolType()),
 		quantifiedVars: ['a'],
 	});
+	// Ordering operators - require the type to implement Ord
+	const lessThanType = functionType(
+		[typeVariable('a'), typeVariable('a')],
+		boolType()
+	);
+	lessThanType.constraints = [implementsConstraint('a', 'Ord')];
 	newEnv.set('<', {
-		type: functionType([typeVariable('a'), typeVariable('a')], boolType()),
+		type: lessThanType,
 		quantifiedVars: ['a'],
 	});
+	const greaterThanType = functionType(
+		[typeVariable('a'), typeVariable('a')],
+		boolType()
+	);
+	greaterThanType.constraints = [implementsConstraint('a', 'Ord')];
 	newEnv.set('>', {
-		type: functionType([typeVariable('a'), typeVariable('a')], boolType()),
+		type: greaterThanType,
 		quantifiedVars: ['a'],
 	});
+	const lessThanOrEqualType = functionType(
+		[typeVariable('a'), typeVariable('a')],
+		boolType()
+	);
+	lessThanOrEqualType.constraints = [implementsConstraint('a', 'Ord')];
 	newEnv.set('<=', {
-		type: functionType([typeVariable('a'), typeVariable('a')], boolType()),
+		type: lessThanOrEqualType,
 		quantifiedVars: ['a'],
 	});
+	const greaterThanOrEqualType = functionType(
+		[typeVariable('a'), typeVariable('a')],
+		boolType()
+	);
+	greaterThanOrEqualType.constraints = [implementsConstraint('a', 'Ord')];
 	newEnv.set('>=', {
-		type: functionType([typeVariable('a'), typeVariable('a')], boolType()),
+		type: greaterThanOrEqualType,
 		quantifiedVars: ['a'],
 	});
 

--- a/src/typer/builtins.ts
+++ b/src/typer/builtins.ts
@@ -99,20 +99,20 @@ export const initializeBuiltins = (state: TypeState): TypeState => {
 		quantifiedVars: ['a'],
 	});
 	newEnv.set('<', {
-		type: functionType([floatType(), floatType()], boolType()),
-		quantifiedVars: [],
+		type: functionType([typeVariable('a'), typeVariable('a')], boolType()),
+		quantifiedVars: ['a'],
 	});
 	newEnv.set('>', {
-		type: functionType([floatType(), floatType()], boolType()),
-		quantifiedVars: [],
+		type: functionType([typeVariable('a'), typeVariable('a')], boolType()),
+		quantifiedVars: ['a'],
 	});
 	newEnv.set('<=', {
-		type: functionType([floatType(), floatType()], boolType()),
-		quantifiedVars: [],
+		type: functionType([typeVariable('a'), typeVariable('a')], boolType()),
+		quantifiedVars: ['a'],
 	});
 	newEnv.set('>=', {
-		type: functionType([floatType(), floatType()], boolType()),
-		quantifiedVars: [],
+		type: functionType([typeVariable('a'), typeVariable('a')], boolType()),
+		quantifiedVars: ['a'],
 	});
 
 	const tailType = functionType(
@@ -411,6 +411,48 @@ export const initializeBuiltins = (state: TypeState): TypeState => {
 	newEnv.set('primitive_string_equals', {
 		type: createBinaryFunctionType(stringType(), stringType(), boolType()),
 		quantifiedVars: [],
+	});
+
+	newEnv.set('primitive_string_less_than', {
+		type: createBinaryFunctionType(stringType(), stringType(), boolType()),
+		quantifiedVars: [],
+	});
+
+	newEnv.set('primitive_string_greater_than', {
+		type: createBinaryFunctionType(stringType(), stringType(), boolType()),
+		quantifiedVars: [],
+	});
+
+	newEnv.set('primitive_string_less_than_or_equal', {
+		type: createBinaryFunctionType(stringType(), stringType(), boolType()),
+		quantifiedVars: [],
+	});
+
+	newEnv.set('primitive_string_greater_than_or_equal', {
+		type: createBinaryFunctionType(stringType(), stringType(), boolType()),
+		quantifiedVars: [],
+	});
+
+	newEnv.set('primitive_float_less_than', {
+		type: createBinaryFunctionType(floatType(), floatType(), boolType()),
+		quantifiedVars: [],
+	});
+
+	// List equality helper: (a -> a -> Bool) -> List a -> List a -> Bool
+	// The predicate is curried (single-param returning single-param returning Bool)
+	newEnv.set('primitive_list_all2', {
+		type: functionType(
+			[
+				functionType(
+					[typeVariable('a')],
+					functionType([typeVariable('a')], boolType())
+				),
+				listTypeWithElement(typeVariable('a')),
+				listTypeWithElement(typeVariable('a')),
+			],
+			boolType()
+		),
+		quantifiedVars: ['a'],
 	});
 
 	// Primitive Subtract trait implementations for type checking

--- a/stdlib.noo
+++ b/stdlib.noo
@@ -172,18 +172,21 @@ implement Functor Option (
   )
 );
 
-#implement Eq Option (
-#  equals = fn opt1 opt2 => match opt1 (
-#    Some x => match opt2 (
-#      Some y => equals x y;
-#      None => False
-#    );
-#    None => match opt2 (   
-#      Some y => False;
-#      None => True
-#    )
-#  )
-#);
+implement Eq (Option a) given a implements Eq (
+  equals = fn o1 o2 => (
+    inner_eq = equals : a -> a -> Bool;
+    match o1 (
+      Some x => match o2 (
+        Some y => inner_eq x y;
+        None => False
+      );
+      None => match o2 (
+        Some y => False;
+        None => True
+      )
+    )
+  )
+);
 
 implement Applicative Option (
   apply = fn f opt => match opt (
@@ -250,19 +253,22 @@ is_err = fn res => match res (
   Err _ => True
 );
 
-#implement Eq Result (
-#  equals = fn res1 res2 => match res1 (
-#    Ok x => match res2 (
-#      Ok y => equals x y;
-#      Err e => False
-#    );
-#
-#    Err e => match res2 (
-#      Ok y => False;
-#      Err e => equals e e
-#    )
-#  )
-#);
+implement Eq (Result a b) given (a implements Eq) and (b implements Eq) (
+  equals = fn r1 r2 => (
+    eq_a = equals : a -> a -> Bool;
+    eq_b = equals : b -> b -> Bool;
+    match r1 (
+      Ok x => match r2 (
+        Ok y => eq_a x y;
+        Err e => False
+      );
+      Err e1 => match r2 (
+        Ok y => False;
+        Err e2 => eq_b e1 e2
+      )
+    )
+  )
+);
 
 implement Applicative Result (
   apply = fn f res => match res (
@@ -312,3 +318,23 @@ implement Show (List a) given a implements Show (
 
 # Note: Eq implementations are handled by built-in primitive functions
 # No need to duplicate them here
+
+implement Eq (List a) given a implements Eq (
+  equals = fn l1 l2 => primitive_list_all2 (equals : a -> a -> Bool) l1 l2
+);
+
+# ========================================
+# ORD TRAIT - Ordering / comparison
+# ========================================
+
+constraint Ord a (
+  less_than : a -> a -> Bool
+);
+
+implement Ord Float (
+  less_than = primitive_float_less_than
+);
+
+implement Ord String (
+  less_than = primitive_string_less_than
+);


### PR DESCRIPTION
## Summary

Extends the Eq String work (commit 6745c3f) to fill confirmed gaps in trait coverage:

- **Eq Option a** — conditional implementation using `given a implements Eq`; handles `Some/Some`, `Some/None`, `None/Some`, `None/None` cases including nested options
- **Eq Result a b** — conditional implementation using `given (a implements Eq) and (b implements Eq)`; handles `Ok/Ok`, `Err/Err`, `Ok/Err`, `Err/Ok` cases  
- **Eq List a** — conditional implementation using `given a implements Eq`; adds `primitive_list_all2` native (element-wise predicate over two lists) to evaluator and type system; handles trait function values via `resolveTraitFunctionWithArgs`
- **Ord trait** — new `constraint Ord a ( less_than : a -> a -> Bool )` with `implement Ord Float` and `implement Ord String`; adds `primitive_float_less_than`, `primitive_string_less_than` (and `greater_than`, `less_than_or_equal`, `greater_than_or_equal`) primitives
- **Polymorphic comparison operators** — `<`, `>`, `<=`, `>=` changed from `Float -> Float -> Bool` to `a -> a -> Bool` in builtins; evaluator updated to handle string operands (Float behaviour unchanged)

Key implementation trick: calling `equals` directly inside an `implement Eq` block caused a type-variable conflict; the fix is capturing `inner_eq = equals : a -> a -> Bool` first, then calling `inner_eq`.

## Test plan

- [x] `eq-collections.test.ts` — 18 tests covering Option, Result, List equality edge cases (written red-first, now green)
- [x] `ord.test.ts` — 16 tests covering `<`, `>`, `<=`, `>=` on strings, Float regression, and `less_than` trait function
- [x] Full suite: **1034 pass / 0 fail / 12 skip** (was 1000/0/12)
- [x] `bun run typecheck` — clean
- [x] `node validate_examples.js` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)