### PR TITLE
Allow subset record destructuring

### DIFF
--- a/src/typer/__tests__/subset-destructuring.test.ts
+++ b/src/typer/__tests__/subset-destructuring.test.ts
@@ -1,0 +1,35 @@
+import { test, expect } from 'bun:test';
+import { runCode, expectError } from '../../../test/utils';
+
+// Record destructuring should bind a SUBSET of a record's fields, like match
+// record patterns already do (issue: destructuring was total, match is partial).
+
+test('subset destructuring - bind one field of a larger record', () => {
+	const r = runCode('{@name} = {@name "A", @age 5}; name');
+	expect(r.finalValue).toBe('A');
+	expect(r.finalType).toBe('String');
+});
+
+test('subset destructuring - bind two of three fields', () => {
+	const r = runCode('{@name, @age} = {@name "A", @age 5, @active True}; age');
+	expect(r.finalValue).toBe(5);
+});
+
+test('subset destructuring - renaming a subset', () => {
+	const r = runCode('{@name userName} = {@name "Alice", @age 30}; userName');
+	expect(r.finalValue).toBe('Alice');
+});
+
+test('subset destructuring - exact match still works', () => {
+	const r = runCode('{@name, @age} = {@name "A", @age 5}; name');
+	expect(r.finalValue).toBe('A');
+});
+
+test('subset destructuring - the module pattern (import a subset)', () => {
+	const r = runCode('{@add} = import "examples/math_module"; add 2 3');
+	expect(r.finalValue).toBe(5);
+});
+
+test('subset destructuring - naming a field the record does not have is rejected', () => {
+	expectError('{@missing} = {@name "A", @age 5}; missing');
+});

--- a/src/typer/type-inference.ts
+++ b/src/typer/type-inference.ts
@@ -1932,11 +1932,21 @@ export const typeRecordDestructuring = (
 		}
 	}
 
-	// Create record type and unify with value
+	// Require the value to have AT LEAST the destructured fields (a subset),
+	// like match record patterns already do — rather than an exact-shape match.
+	// Mirror accessors: constrain a fresh record variable to "has these fields"
+	// and unify the value with it, so extra fields on the value are allowed.
 	const expectedRecordType = recordType(fieldTypes);
+	const [recordVar, varState] = freshTypeVariable(currentState);
+	currentState = varState;
+	if (recordVar.kind === 'variable') {
+		recordVar.constraints = [
+			hasStructureConstraint(recordVar.name, { fields: fieldTypes }),
+		];
+	}
 	currentState = unify(
 		valueResult.type,
-		expectedRecordType,
+		recordVar,
 		currentState,
 		getExprLocation(expr)
 	);

--- a/test/language-features/destructuring.test.ts
+++ b/test/language-features/destructuring.test.ts
@@ -98,8 +98,10 @@ test('should handle mixed tuple and record destructuring', () => {
 });
 
 test('should throw error for missing fields in record destructuring', () => {
+	// Destructuring binds a subset of a record's fields, but naming a field the
+	// record does not have is still rejected (now at type-check time).
 	const source = '{@name, @missing} = {@name "Test"}';
-	expect(() => runCode(source)).toThrow('Field \'missing\' not found in record');
+	expect(() => runCode(source)).toThrow(/missing required field @missing/);
 });
 
 test('should throw error for tuple length mismatch', () => {


### PR DESCRIPTION
Record destructuring bindings required an **exact** field match:

```noolang
{@name} = {@name "A", @age 5}   # before: TypeError: Required field missing: age
```

…while `match` record patterns already bind a **subset**. This inconsistency (destructuring total, match partial) made the destructure-a-module pattern painful — `{@add} = import "mathModule"` failed whenever the module exported anything else.

## Change
Align destructuring with `match`: constrain the value to have **at least** the named fields via a structural `has`-field constraint (mirroring how accessors already work), instead of unifying against an exact record shape.

- Extra fields on the value are now allowed.
- Naming a field the record lacks is still rejected — now at **type-check** time with a clearer message (`Record missing required field @x …`).
- `{@add} = import "examples/math_module"` now works even though the module also exports `@multiply`.

## Tests
- New `subset-destructuring.test.ts` (6 cases incl. the module pattern), proven red→green (4 fail without the change).
- Updated one existing test whose assertion encoded the old exact-match message.
- Full suite: **1051 pass / 0 fail**; `tsc` clean; `validate_examples.js` exit 0.

Prerequisite for the module system (#109). The complementary question — whether `match` record patterns should stay partial — is tracked in #111.