### PR TITLE
Accept trait functions in reduce (and peer list builtins)

### DIFF
--- a/src/evaluator/evaluator.ts
+++ b/src/evaluator/evaluator.ts
@@ -549,6 +549,19 @@ export class Evaluator {
 								'reduce function must return a function after first argument'
 							);
 						}, initial);
+					} else if (isTraitFunctionValue(func) && isList(list)) {
+						// Handle bare trait functions (e.g. `add`, `multiply`) as reducers.
+						// Resolve the trait implementation for each (acc, item) pair directly.
+						return list.values.reduce((acc: Value, item: Value) => {
+							const allArgs = func.partialArgs
+								? [...func.partialArgs, acc, item]
+								: [acc, item];
+							return this.resolveTraitFunctionWithArgs(
+								func.name,
+								allArgs,
+								func.traitRegistry
+							);
+						}, initial);
 					}
 					throw new Error(
 						createHOFError('reduce', ['a function', 'initial value', 'a list'])

--- a/src/typer/__tests__/reduce-trait-fn.test.ts
+++ b/src/typer/__tests__/reduce-trait-fn.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Tests that `reduce` (and peer list builtins) accept bare trait functions
+ * as the reducer/callback argument.
+ *
+ * Regression: previously `reduce add 0 [1,2,3]` threw
+ * "reduce requires a function, initial value, a list" because the runtime
+ * check only allowed ordinary function/native-function values and did not
+ * handle the `trait-function` value kind.
+ */
+import { describe, test, expect } from 'bun:test';
+import { expectSuccess, expectError } from '../../../test/utils';
+
+describe('reduce with bare trait functions', () => {
+	test('reduce add 0 [1,2,3] → 6', () => {
+		expectSuccess('reduce add 0 [1,2,3]', 6);
+	});
+
+	test('reduce add 0 [] → 0 (empty list)', () => {
+		expectSuccess('reduce add 0 []', 0);
+	});
+
+	test('reduce multiply 1 [1,2,3,4] → 24', () => {
+		expectSuccess('reduce multiply 1 [1,2,3,4]', 24);
+	});
+
+	test('reduce subtract 10 [1,2,3] → 4', () => {
+		// 10 - 1 = 9, 9 - 2 = 7, 7 - 3 = 4
+		expectSuccess('reduce subtract 10 [1,2,3]', 4);
+	});
+
+	test('reduce still works with a plain lambda', () => {
+		expectSuccess('reduce (fn acc x => acc + x) 0 [1,2,3]', 6);
+	});
+
+	test('result has Float type', () => {
+		const result = expectSuccess('reduce add 0 [1,2,3]');
+		expect(result.finalType).toBe('Float');
+	});
+
+	test('reduce add works with single-element list', () => {
+		expectSuccess('reduce add 0 [42]', 42);
+	});
+});


### PR DESCRIPTION
## Summary

- **Root cause**: the `reduce` builtin's runtime guard (`isFunction(func) || isNativeFunction(func)`) did not handle the `trait-function` value kind, which is what you get when you write a bare trait method reference like `add` or `multiply`. The fix adds an `isTraitFunctionValue` branch that calls `resolveTraitFunctionWithArgs` with both the accumulator and current item for each step, exactly matching the pattern already used by `primitive_list_all2`.
- **Builtins fixed**: `reduce` only. After audit: `list_map` and `primitive_list_all2` already handled trait functions; the predicate-based builtins (`list_filter`, `list_any`, `list_find`, `find`) don't need changes because partial trait-fn application (e.g. `equals 5`) resolves to a native function before reaching them.
- **Tests**: 7 new regression tests in `src/typer/__tests__/reduce-trait-fn.test.ts` covering `add`, `multiply`, `subtract`, empty-list edge case, and plain-lambda compatibility.

## Test plan

- [ ] `reduce add 0 [1,2,3]` → `6`
- [ ] `reduce multiply 1 [1,2,3,4]` → `24`
- [ ] `reduce subtract 10 [1,2,3]` → `4`
- [ ] `reduce (fn acc x => acc + x) 0 [1,2,3]` → `6` (regression: existing lambda form still works)
- [ ] `AGENT=1 bun test` — 1052 pass / 0 fail (up from 1045 baseline; +7 new tests)
- [ ] `bun run typecheck` — clean
- [ ] `node validate_examples.js` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)