### PR TITLE
Resolve concrete return type of direct trait-function calls

### DIFF
--- a/src/typer/__tests__/trait-return-type.test.ts
+++ b/src/typer/__tests__/trait-return-type.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Tests for correct return type resolution when calling trait functions directly.
+ *
+ * Regression test for the bug where `equals 1 2` returned `a` (an unresolved type
+ * variable) instead of `Bool`. Root cause: handlePartialTraitFunctionApplication was
+ * incorrectly adding concrete type constructor names like 'Bool' to its set of type
+ * variables to freshen, replacing them with fresh unresolved variables.
+ */
+import { test, expect, describe } from 'bun:test';
+import { typeToString } from '../helpers';
+import { parseAndType } from '../../../test/utils';
+
+describe('trait function direct calls resolve concrete return types', () => {
+	test('equals 1 2 returns Bool', () => {
+		const result = parseAndType('equals 1 2');
+		const typeStr = typeToString(result.type, result.state.substitution);
+		expect(typeStr).toBe('Bool');
+	});
+
+	test('equals "a" "b" returns Bool', () => {
+		const result = parseAndType('equals "a" "b"');
+		const typeStr = typeToString(result.type, result.state.substitution);
+		expect(typeStr).toBe('Bool');
+	});
+
+	test('equals True False returns Bool (Bool implements Eq)', () => {
+		const result = parseAndType('equals True False');
+		const typeStr = typeToString(result.type, result.state.substitution);
+		expect(typeStr).toBe('Bool');
+	});
+
+	test('show 42 returns String', () => {
+		const result = parseAndType('show 42');
+		const typeStr = typeToString(result.type, result.state.substitution);
+		expect(typeStr).toBe('String');
+	});
+
+	test('show "hello" returns String', () => {
+		const result = parseAndType('show "hello"');
+		const typeStr = typeToString(result.type, result.state.substitution);
+		expect(typeStr).toBe('String');
+	});
+
+	test('equals via == operator also returns Bool', () => {
+		const result = parseAndType('1 == 2');
+		const typeStr = typeToString(result.type, result.state.substitution);
+		expect(typeStr).toBe('Bool');
+	});
+
+	test('partial application of equals preserves Bool in return position', () => {
+		// equals 1 returns Float -> Bool
+		const result = parseAndType('equals 1');
+		const typeStr = typeToString(result.type, result.state.substitution);
+		expect(typeStr).toBe('Float -> Bool');
+	});
+});

--- a/src/typer/trait-function-handling.ts
+++ b/src/typer/trait-function-handling.ts
@@ -122,8 +122,13 @@ function handlePartialTraitFunctionApplication(
 		if (type.kind === 'variable') {
 			freeVars.add(type.name);
 		} else if (type.kind === 'variant') {
-			// Include variant names (like 'f' in 'f a') as variables to be freshened
-			freeVars.add(type.name);
+			// Only include lowercase variant names as type variables to be freshened.
+			// These represent type parameters like 'f' in 'f a' (for Functor-style traits).
+			// Concrete type constructors like 'Bool', 'Option', 'List' start with uppercase
+			// and must NOT be freshened — doing so replaces them with unresolved type vars.
+			if (type.name.length > 0 && type.name[0] === type.name[0].toLowerCase() && type.name[0] !== type.name[0].toUpperCase()) {
+				freeVars.add(type.name);
+			}
 			type.args.forEach(collectVars);
 		} else if (type.kind === 'function') {
 			type.params.forEach(collectVars);


### PR DESCRIPTION
## Summary

- **Root cause**: In `handlePartialTraitFunctionApplication` (`src/typer/trait-function-handling.ts`), the `collectVars` helper was adding ALL variant type names — including concrete constructors like `Bool`, `Option`, `List` — to the set of free variables to freshen. When the trait function type `a -> a -> Bool` was freshened for partial application, `Bool` got replaced by a fresh unresolved type variable (e.g. `α217`), so `equals 1 2` reported type `a` instead of `Bool`.
- **Fix**: Only freshen variant names that start with a lowercase letter. In Noolang's type system, lowercase names are type parameters (e.g. `f` in `f a` for Functor); uppercase names are concrete constructors (`Bool`, `Option`, etc.) and must be left untouched.
- **Tests**: New file `src/typer/__tests__/trait-return-type.test.ts` with 7 regression tests covering `equals` on numbers/strings/Bool and `show` on numbers/strings.

## Test plan

- [x] `bun src/cli.ts --types 'equals 1 2'` → `Bool`
- [x] `bun src/cli.ts --types 'equals "a" "b"'` → `Bool`
- [x] `bun src/cli.ts --types '1 == 2'` → `Bool` (unchanged)
- [x] `AGENT=1 bun test` → 1052 pass, 0 fail
- [x] `bun run typecheck` → clean
- [x] `node validate_examples.js` → exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)