### PR TITLE
Don't swallow import type errors

### DIFF
--- a/src/typer/__tests__/import-error-propagation.test.ts
+++ b/src/typer/__tests__/import-error-propagation.test.ts
@@ -1,0 +1,38 @@
+import { test, expect } from 'bun:test';
+import * as fs from 'node:fs';
+import { runCode, parseAndType } from '../../../test/utils';
+
+// Regression: a type error inside an imported module must surface. Previously
+// typeImport swallowed any import failure and returned a fresh type variable,
+// so misuse of a broken module silently type-checked.
+
+const withModule = (name: string, contents: string, body: () => void) => {
+	const file = `${name}.noo`;
+	fs.writeFileSync(file, contents);
+	try {
+		body();
+	} finally {
+		fs.unlinkSync(file);
+	}
+};
+
+test('import of a module containing a type error surfaces the error at type-check', () => {
+	// Uses parseAndType (type-check only): with the swallow, misuse of the broken
+	// module's value would type-check as String; with the fix it must throw.
+	withModule('_test_bad_import_module', 'bad = 1 + "hello";\n{@val bad}\n', () => {
+		expect(() =>
+			parseAndType('m = import "_test_bad_import_module"; concat (m | @val) "x"')
+		).toThrow();
+	});
+});
+
+test('import of a valid module still works', () => {
+	withModule(
+		'_test_ok_import_module',
+		'addFn = fn x y => x + y;\n{@add addFn}\n',
+		() => {
+			const r = runCode('{@add} = import "_test_ok_import_module"; add 2 3');
+			expect(r.finalValue).toBe(5);
+		}
+	);
+});

--- a/src/typer/type-inference.ts
+++ b/src/typer/type-inference.ts
@@ -1244,11 +1244,17 @@ export const typeImport = (
 
 		// Return the type of the final statement
 		return createPureTypeResult(finalType, currentState);
-	} catch (_error) {
-		// If import fails, we fall back to a type variable to avoid breaking the whole type check
-		// This allows gradual typing and better error messages
-		const [freshVar, newState] = freshTypeVariable(state);
-		return createPureTypeResult(freshVar, newState);
+	} catch (error) {
+		// Do NOT swallow import failures. A type error (or missing file) inside an
+		// imported module must surface — otherwise the import's type silently
+		// becomes an unconstrained type variable that unifies with anything, so
+		// misuse of a broken module type-checks. Surface with context.
+		const reason = error instanceof Error ? error.message : String(error);
+		throwTypeError(
+			location =>
+				createTypeError(`Failed to import '${expr.path}': ${reason}`, {}, location),
+			getExprLocation(expr)
+		);
 	}
 };
 


### PR DESCRIPTION
A soundness bug surfaced by the module-system design review (#109).

`typeImport` wrapped its whole body in a catch that returned a fresh type variable on **any** failure — including a type error inside the imported module. That variable unifies with anything, so misuse of a broken module type-checks:

```
# module _bad.noo:  bad = 1 + "hello"; {@val bad}
m = import "_bad"; concat (m | @val) "x"   # was: : String (error swallowed)
```

Now the underlying error propagates with context (`Failed to import '…': …`). Valid imports are unaffected.

## Tests
- New `import-error-propagation.test.ts` (type-check-level, so it isolates the typer swallow), proven red→green.
- Full suite: **1045 pass / 0 fail**; typecheck clean; docs validated.

Part of the 'fix existing soundness bugs first' pass before revising the module plan. Related follow-ups from the review (CWD/file-dir divergence, name-keyed ADT identity) are better handled with the module resolution rework.