### PR TITLE
Enforce exhaustiveness for variant matches

### DIFF
--- a/src/typer/__tests__/match-exhaustiveness.test.ts
+++ b/src/typer/__tests__/match-exhaustiveness.test.ts
@@ -1,0 +1,46 @@
+import { test, expect } from 'bun:test';
+import { parseAndType, runCode } from '../../../test/utils';
+
+// A match on a concrete variant must cover every constructor or have a
+// catch-all; otherwise it is a type error.
+
+test('non-exhaustive Option match is rejected', () => {
+	expect(() => parseAndType('match (Some 1) (Some x => x)')).toThrow(
+		/Non-exhaustive match on Option: missing case None/
+	);
+});
+
+test('non-exhaustive Result match is rejected', () => {
+	expect(() => parseAndType('fn r => match r (Ok x => x)')).toThrow(
+		/missing case Err/
+	);
+});
+
+test('non-exhaustive custom variant reports every missing constructor', () => {
+	expect(() =>
+		parseAndType('variant C = R | G | B; match R (R => 1)')
+	).toThrow(/missing cases G, B/);
+});
+
+test('non-exhaustive Bool match is rejected', () => {
+	expect(() => parseAndType('fn b => match b (True => 1)')).toThrow(
+		/missing case False/
+	);
+});
+
+test('exhaustive match is accepted', () => {
+	expect(runCode('match (Some 1) (Some x => x; None => 0)').finalValue).toBe(1);
+});
+
+test('a wildcard makes a match exhaustive', () => {
+	expect(runCode('match (Some 1) (Some x => x; _ => 0)').finalValue).toBe(1);
+});
+
+test('a variable catch-all makes a match exhaustive', () => {
+	expect(runCode('variant C = R | G | B; match G (R => 1; other => 2)').finalValue).toBe(2);
+});
+
+test('a match on a non-variant / still-polymorphic scrutinee is not flagged', () => {
+	// `fn x => match x (_ => 1)` — scrutinee never resolves to a variant.
+	expect(() => parseAndType('fn x => match x (_ => 1)')).not.toThrow();
+});

--- a/src/typer/pattern-matching.ts
+++ b/src/typer/pattern-matching.ts
@@ -21,7 +21,13 @@ import { substitute } from './substitute';
 import { unify } from './unify';
 import { freshTypeVariable, isReservedTypeName } from './type-operations';
 import { typeExpression } from './expression-dispatcher';
-import { isTypeKind, typeToString } from './helpers';
+import {
+	isTypeKind,
+	typeToString,
+	throwTypeError,
+	getExprLocation,
+} from './helpers';
+import { createTypeError } from './type-errors';
 
 // Type inference for ADT type definitions
 export const typeTypeDefinition = (
@@ -267,7 +273,52 @@ export const typeMatch = (
 		resultType = substitute(resultType, currentState.substitution);
 	}
 
+	checkExhaustiveness(expr, exprResult.type, currentState);
+
 	return createTypeResult(resultType, allEffects, currentState);
+};
+
+// A match on a concrete variant must cover every constructor, unless it has a
+// catch-all (wildcard `_` or a bare variable pattern). If the scrutinee type is
+// still polymorphic (a type variable) or not a known variant, we can't and
+// don't check.
+const checkExhaustiveness = (
+	expr: MatchExpression,
+	scrutineeType: Type,
+	state: TypeState
+): void => {
+	const resolved = substitute(scrutineeType, state.substitution);
+	if (resolved.kind !== 'variant' || !state.adtRegistry.has(resolved.name)) {
+		return;
+	}
+
+	const hasCatchAll = expr.cases.some(
+		c => c.pattern.kind === 'wildcard' || c.pattern.kind === 'variable'
+	);
+	if (hasCatchAll) return;
+
+	const covered = new Set<string>();
+	for (const c of expr.cases) {
+		if (c.pattern.kind === 'constructor') covered.add(c.pattern.name);
+	}
+
+	const allConstructors = state.adtRegistry.get(resolved.name)!.constructors;
+	const missing = [...allConstructors.keys()].filter(name => !covered.has(name));
+	if (missing.length > 0) {
+		throwTypeError(
+			location =>
+				createTypeError(
+					`Non-exhaustive match on ${resolved.name}: missing case${
+						missing.length > 1 ? 's' : ''
+					} ${missing.join(', ')}. Add ${
+						missing.length > 1 ? 'them' : 'it'
+					} or a wildcard \`_\` case.`,
+					{},
+					location
+				),
+			getExprLocation(expr)
+		);
+	}
 };
 
 // Type a single match case


### PR DESCRIPTION
The reliability gap from the case-coverage discussion: a non-exhaustive `match` on a variant was silently accepted and could fail at runtime.

```
match (Some 1) (Some x => x)
→ TypeError: Non-exhaustive match on Option: missing case None. Add it or a wildcard `_` case.
```

## Behavior
- A match whose scrutinee resolves to a **known variant** must cover **every constructor**, or include a catch-all (`_` wildcard or a bare variable pattern). Missing constructors are named in the error.
- Fires for `Option` / `Result` / `Bool` / user variants, in both literal and function-parameter position.
- **Not** flagged: polymorphic or non-variant scrutinees (no false positives). Out of scope: redundant/unreachable-arm detection, and literal/tuple/record exhaustiveness.

## Impact
It's a **hard error** (the sound choice), but the entire existing codebase already matched exhaustively — full suite stays **1067 pass / 0 fail**, docs validate, typecheck clean.

## Tests
New `match-exhaustiveness.test.ts` (8 cases), proven red→green (4 fail without the change).

Complements #111 (revisit `match` record-pattern partiality).
