### PR TITLE
Module system step 1: declaration manifest + merge

### DIFF
--- a/src/typer/__tests__/module-manifest.test.ts
+++ b/src/typer/__tests__/module-manifest.test.ts
@@ -1,0 +1,420 @@
+/**
+ * Tests for the module declaration manifest + merge primitive (Phase 1, Step 1).
+ *
+ * All manifests are constructed in-memory — no file I/O, no resolution.
+ * The fail-closed tests (conflict/orphan) are the point: they must be red
+ * before the merge logic exists, and green after.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import {
+	type Manifest,
+	type ManifestADT,
+	type ManifestInstance,
+	type ManifestTraitDef,
+	emptyManifest,
+	mergeManifests,
+	validateOrphanRule,
+} from '../module-manifest';
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+function mkInstance(
+	traitName: string,
+	typeName: string,
+	definingPath: string
+): ManifestInstance {
+	return { traitName, typeName, definingPath };
+}
+
+function mkADT(name: string, definingPath: string): ManifestADT {
+	return { name, definingPath, typeParams: [], constructors: new Map() };
+}
+
+function mkTraitDef(name: string, definingPath: string): ManifestTraitDef {
+	return { name, definingPath };
+}
+
+function mkManifest(
+	adts: ManifestADT[] = [],
+	instances: ManifestInstance[] = [],
+	traitDefs: ManifestTraitDef[] = []
+): Manifest {
+	return { adts, instances, traitDefs };
+}
+
+// ─── instance dedup ───────────────────────────────────────────────────────────
+
+describe('mergeManifests — instance dedup', () => {
+	test('same (trait, type, definingPath) merged twice → one entry, no error', () => {
+		const inst = mkInstance('Eq', 'String', '/lib/eq_string.noo');
+		const a = mkManifest([], [inst]);
+		const b = mkManifest([], [inst]);
+		const result = mergeManifests(a, b);
+		expect(result.instances).toHaveLength(1);
+		expect(result.instances[0]).toEqual(inst);
+	});
+
+	test('different (trait, type) pair — both kept', () => {
+		const a = mkManifest([], [mkInstance('Eq', 'String', '/lib/eq.noo')]);
+		const b = mkManifest([], [mkInstance('Ord', 'String', '/lib/ord.noo')]);
+		const result = mergeManifests(a, b);
+		expect(result.instances).toHaveLength(2);
+	});
+
+	test('same trait, different type — both kept', () => {
+		const a = mkManifest([], [mkInstance('Eq', 'String', '/lib/eq.noo')]);
+		const b = mkManifest([], [mkInstance('Eq', 'Float', '/lib/eq.noo')]);
+		const result = mergeManifests(a, b);
+		expect(result.instances).toHaveLength(2);
+	});
+});
+
+// ─── instance conflict (fail-closed) ─────────────────────────────────────────
+
+describe('mergeManifests — instance conflict (fail-closed)', () => {
+	test('same (trait, type), two different definingPaths → throws', () => {
+		const a = mkManifest([], [mkInstance('Eq', 'String', '/moduleA/lib.noo')]);
+		const b = mkManifest([], [mkInstance('Eq', 'String', '/moduleB/lib.noo')]);
+		expect(() => mergeManifests(a, b)).toThrow();
+	});
+
+	test('conflict error names BOTH files', () => {
+		const pathA = '/moduleA/lib.noo';
+		const pathB = '/moduleB/lib.noo';
+		const a = mkManifest([], [mkInstance('Eq', 'String', pathA)]);
+		const b = mkManifest([], [mkInstance('Eq', 'String', pathB)]);
+		let msg = '';
+		try {
+			mergeManifests(a, b);
+		} catch (e) {
+			msg = (e as Error).message;
+		}
+		expect(msg).toContain(pathA);
+		expect(msg).toContain(pathB);
+	});
+
+	test('conflict is order-independent (merge(a,b) and merge(b,a) both throw)', () => {
+		const pathA = '/moduleA/lib.noo';
+		const pathB = '/moduleB/lib.noo';
+		const a = mkManifest([], [mkInstance('Eq', 'String', pathA)]);
+		const b = mkManifest([], [mkInstance('Eq', 'String', pathB)]);
+		expect(() => mergeManifests(a, b)).toThrow();
+		expect(() => mergeManifests(b, a)).toThrow();
+	});
+
+	test('conflict message names both files regardless of order', () => {
+		const pathA = '/moduleA/lib.noo';
+		const pathB = '/moduleB/lib.noo';
+		const a = mkManifest([], [mkInstance('Functor', 'List', pathA)]);
+		const b = mkManifest([], [mkInstance('Functor', 'List', pathB)]);
+
+		let msgAB = '';
+		let msgBA = '';
+		try { mergeManifests(a, b); } catch (e) { msgAB = (e as Error).message; }
+		try { mergeManifests(b, a); } catch (e) { msgBA = (e as Error).message; }
+
+		// Both orders name both files
+		expect(msgAB).toContain(pathA);
+		expect(msgAB).toContain(pathB);
+		expect(msgBA).toContain(pathA);
+		expect(msgBA).toContain(pathB);
+	});
+});
+
+// ─── ADT dedup ────────────────────────────────────────────────────────────────
+
+describe('mergeManifests — ADT dedup', () => {
+	test('same (definingPath, name) merged twice → one entry', () => {
+		const adt = mkADT('Option', '/std/option.noo');
+		const a = mkManifest([adt]);
+		const b = mkManifest([adt]);
+		const result = mergeManifests(a, b);
+		expect(result.adts).toHaveLength(1);
+	});
+
+	test('different name same path — both kept', () => {
+		const a = mkManifest([mkADT('Option', '/std/prelude.noo')]);
+		const b = mkManifest([mkADT('Result', '/std/prelude.noo')]);
+		const result = mergeManifests(a, b);
+		expect(result.adts).toHaveLength(2);
+	});
+
+	test('same name same path — dedupe (exact same entry, no error)', () => {
+		const adt = mkADT('Box', '/lib/box.noo');
+		const a = mkManifest([adt]);
+		const b = mkManifest([adt]);
+		const result = mergeManifests(a, b);
+		expect(result.adts).toHaveLength(1);
+	});
+});
+
+// ─── ADT collision (fail-closed) ──────────────────────────────────────────────
+
+describe('mergeManifests — ADT collision (fail-closed)', () => {
+	test('same name, different definingPath → throws', () => {
+		const a = mkManifest([mkADT('Box', '/moduleA/types.noo')]);
+		const b = mkManifest([mkADT('Box', '/moduleB/types.noo')]);
+		expect(() => mergeManifests(a, b)).toThrow();
+	});
+
+	test('ADT collision error names both files', () => {
+		const pathA = '/moduleA/types.noo';
+		const pathB = '/moduleB/types.noo';
+		const a = mkManifest([mkADT('Box', pathA)]);
+		const b = mkManifest([mkADT('Box', pathB)]);
+		let msg = '';
+		try { mergeManifests(a, b); } catch (e) { msg = (e as Error).message; }
+		expect(msg).toContain(pathA);
+		expect(msg).toContain(pathB);
+	});
+
+	test('ADT collision is order-independent', () => {
+		const a = mkManifest([mkADT('Tree', '/moduleA/tree.noo')]);
+		const b = mkManifest([mkADT('Tree', '/moduleB/tree.noo')]);
+		expect(() => mergeManifests(a, b)).toThrow();
+		expect(() => mergeManifests(b, a)).toThrow();
+	});
+});
+
+// ─── trait definition dedup & collision ───────────────────────────────────────
+
+describe('mergeManifests — trait definition dedup & collision', () => {
+	test('same (definingPath, name) merged twice → one entry', () => {
+		const td = mkTraitDef('Eq', '/std/eq.noo');
+		const a = mkManifest([], [], [td]);
+		const b = mkManifest([], [], [td]);
+		const result = mergeManifests(a, b);
+		expect(result.traitDefs).toHaveLength(1);
+	});
+
+	test('same name, different definingPath → throws', () => {
+		const a = mkManifest([], [], [mkTraitDef('Eq', '/moduleA/eq.noo')]);
+		const b = mkManifest([], [], [mkTraitDef('Eq', '/moduleB/eq.noo')]);
+		expect(() => mergeManifests(a, b)).toThrow();
+	});
+
+	test('trait def collision error names both files', () => {
+		const pathA = '/moduleA/eq.noo';
+		const pathB = '/moduleB/eq.noo';
+		const a = mkManifest([], [], [mkTraitDef('Eq', pathA)]);
+		const b = mkManifest([], [], [mkTraitDef('Eq', pathB)]);
+		let msg = '';
+		try { mergeManifests(a, b); } catch (e) { msg = (e as Error).message; }
+		expect(msg).toContain(pathA);
+		expect(msg).toContain(pathB);
+	});
+});
+
+// ─── commutativity & associativity ───────────────────────────────────────────
+
+describe('mergeManifests — commutativity & associativity', () => {
+	test('merge(a,b) and merge(b,a) yield same result (commutativity)', () => {
+		const a = mkManifest(
+			[mkADT('Option', '/std/option.noo')],
+			[mkInstance('Eq', 'String', '/std/eq.noo')],
+			[mkTraitDef('Eq', '/std/eq.noo')]
+		);
+		const b = mkManifest(
+			[mkADT('Result', '/std/result.noo')],
+			[mkInstance('Eq', 'Float', '/std/eq.noo')],
+			[mkTraitDef('Ord', '/std/ord.noo')]
+		);
+		const ab = mergeManifests(a, b);
+		const ba = mergeManifests(b, a);
+
+		// Same counts
+		expect(ab.adts).toHaveLength(ba.adts.length);
+		expect(ab.instances).toHaveLength(ba.instances.length);
+		expect(ab.traitDefs).toHaveLength(ba.traitDefs.length);
+
+		// Same names (order may differ, so sort)
+		const adtNamesAB = ab.adts.map(x => x.name).sort();
+		const adtNamesBA = ba.adts.map(x => x.name).sort();
+		expect(adtNamesAB).toEqual(adtNamesBA);
+
+		const instKeysAB = ab.instances.map(x => `${x.traitName}:${x.typeName}`).sort();
+		const instKeysBA = ba.instances.map(x => `${x.traitName}:${x.typeName}`).sort();
+		expect(instKeysAB).toEqual(instKeysBA);
+	});
+
+	test('associativity: merge(merge(a,b),c) ≡ merge(a,merge(b,c))', () => {
+		const a = mkManifest(
+			[mkADT('Option', '/std/option.noo')],
+			[mkInstance('Eq', 'String', '/std/eq.noo')]
+		);
+		const b = mkManifest(
+			[mkADT('Result', '/std/result.noo')],
+			[mkInstance('Ord', 'Float', '/std/ord.noo')]
+		);
+		const c = mkManifest(
+			[mkADT('List', '/std/list.noo')],
+			[mkInstance('Functor', 'List', '/std/functor.noo')]
+		);
+
+		const abc_left = mergeManifests(mergeManifests(a, b), c);
+		const abc_right = mergeManifests(a, mergeManifests(b, c));
+
+		const sortADTs = (m: Manifest) => m.adts.map(x => x.name).sort();
+		const sortInsts = (m: Manifest) =>
+			m.instances.map(x => `${x.traitName}:${x.typeName}`).sort();
+
+		expect(sortADTs(abc_left)).toEqual(sortADTs(abc_right));
+		expect(sortInsts(abc_left)).toEqual(sortInsts(abc_right));
+	});
+
+	test('conflict detected regardless of order — associativity holds for errors too', () => {
+		const pathA = '/moduleA/lib.noo';
+		const pathB = '/moduleB/lib.noo';
+		const a = mkManifest([], [mkInstance('Eq', 'String', pathA)]);
+		const b = mkManifest([], [mkInstance('Eq', 'String', pathB)]);
+		const c = mkManifest([], [mkInstance('Ord', 'Float', '/std/ord.noo')]);
+
+		// merge(a,b) throws; thus merge(merge(a,b),c) throws
+		expect(() => mergeManifests(mergeManifests(a, b), c)).toThrow();
+		// merge(b,a) throws; thus merge(a,merge(b,a)) — can't use due to inner throw
+		// Instead: the two different conflict-detecting merge calls both throw
+		expect(() => mergeManifests(a, b)).toThrow();
+		expect(() => mergeManifests(b, a)).toThrow();
+	});
+});
+
+// ─── empty manifest identity ──────────────────────────────────────────────────
+
+describe('mergeManifests — empty manifest', () => {
+	test('merge(empty, a) === a', () => {
+		const a = mkManifest(
+			[mkADT('Option', '/std/option.noo')],
+			[mkInstance('Eq', 'String', '/std/eq.noo')],
+			[mkTraitDef('Eq', '/std/eq.noo')]
+		);
+		const result = mergeManifests(emptyManifest(), a);
+		expect(result.adts).toHaveLength(1);
+		expect(result.instances).toHaveLength(1);
+		expect(result.traitDefs).toHaveLength(1);
+	});
+
+	test('merge(a, empty) === a', () => {
+		const a = mkManifest(
+			[mkADT('Option', '/std/option.noo')],
+			[mkInstance('Eq', 'String', '/std/eq.noo')]
+		);
+		const result = mergeManifests(a, emptyManifest());
+		expect(result.adts).toHaveLength(1);
+		expect(result.instances).toHaveLength(1);
+	});
+});
+
+// ─── orphan rule ──────────────────────────────────────────────────────────────
+
+describe('validateOrphanRule', () => {
+	test('instance co-located with trait → NOT orphan', () => {
+		// Eq defined in /lib/eq.noo; instance of Eq for UserType also in /lib/eq.noo
+		const manifest = mkManifest(
+			[mkADT('UserType', '/app/types.noo')],
+			[mkInstance('Eq', 'UserType', '/lib/eq.noo')],
+			[mkTraitDef('Eq', '/lib/eq.noo')]
+		);
+		expect(() => validateOrphanRule(manifest)).not.toThrow();
+	});
+
+	test('instance co-located with type → NOT orphan', () => {
+		// Eq defined elsewhere; instance of Eq for MyType in same file as MyType
+		const manifest = mkManifest(
+			[mkADT('MyType', '/app/mytype.noo')],
+			[mkInstance('Eq', 'MyType', '/app/mytype.noo')],
+			[mkTraitDef('Eq', '/std/eq.noo')]
+		);
+		expect(() => validateOrphanRule(manifest)).not.toThrow();
+	});
+
+	test('std/* instance for another std/* trait/type → NOT orphan (coherence unit)', () => {
+		// Instance in std/list_instances.noo for trait Functor in std/functor.noo
+		// and type List in std/list.noo — all std, no orphan
+		const manifest = mkManifest(
+			[mkADT('List', 'std/list.noo')],
+			[mkInstance('Functor', 'List', 'std/list_instances.noo')],
+			[mkTraitDef('Functor', 'std/functor.noo')]
+		);
+		expect(() => validateOrphanRule(manifest)).not.toThrow();
+	});
+
+	test('orphan instance (neither with trait nor type, not std) → throws (fail-closed)', () => {
+		// Eq defined in std/; List defined in std/; but instance in /userApp/orphan.noo
+		const manifest = mkManifest(
+			[mkADT('List', 'std/list.noo')],
+			[mkInstance('Eq', 'List', '/userApp/orphan.noo')],
+			[mkTraitDef('Eq', 'std/eq.noo')]
+		);
+		expect(() => validateOrphanRule(manifest)).toThrow();
+	});
+
+	test('orphan error message names the instance defining path', () => {
+		const orphanPath = '/userApp/orphan.noo';
+		const manifest = mkManifest(
+			[mkADT('List', 'std/list.noo')],
+			[mkInstance('Eq', 'List', orphanPath)],
+			[mkTraitDef('Eq', 'std/eq.noo')]
+		);
+		let msg = '';
+		try { validateOrphanRule(manifest); } catch (e) { msg = (e as Error).message; }
+		expect(msg).toContain(orphanPath);
+	});
+
+	test('instance for unknown type (primitive) is only checked against trait location', () => {
+		// Float is a primitive — no ADT entry. Instance in std/eq.noo with trait Eq also in std/eq.noo → ok
+		const manifest = mkManifest(
+			[],
+			[mkInstance('Eq', 'Float', 'std/eq.noo')],
+			[mkTraitDef('Eq', 'std/eq.noo')]
+		);
+		expect(() => validateOrphanRule(manifest)).not.toThrow();
+	});
+
+	test('instance for unknown type, not with trait → orphan (fail-closed)', () => {
+		// Float is a primitive (no ADT), instance in /userApp/extra.noo, trait in std/
+		const manifest = mkManifest(
+			[],
+			[mkInstance('Eq', 'Float', '/userApp/extra.noo')],
+			[mkTraitDef('Eq', 'std/eq.noo')]
+		);
+		expect(() => validateOrphanRule(manifest)).toThrow();
+	});
+});
+
+// ─── diamond dedup (no false duplicate errors) ────────────────────────────────
+
+describe('mergeManifests — diamond pattern (A→B→D, A→C→D)', () => {
+	test('D defines instance; merging via both paths gives one entry, no error', () => {
+		// D's manifest appears in both B and C (via transitive merge)
+		const dManifest = mkManifest(
+			[mkADT('Token', '/d/types.noo')],
+			[mkInstance('Eq', 'Token', '/d/types.noo')],
+			[mkTraitDef('Eq', '/d/eq.noo')]
+		);
+
+		// B has its own + D's
+		const bManifest = mergeManifests(
+			mkManifest([], [mkInstance('Ord', 'Int', '/b/ord.noo')]),
+			dManifest
+		);
+
+		// C has its own + D's
+		const cManifest = mergeManifests(
+			mkManifest([], [mkInstance('Show', 'Bool', '/c/show.noo')]),
+			dManifest
+		);
+
+		// A merges B and C — D's declarations should dedupe, not conflict
+		expect(() => mergeManifests(bManifest, cManifest)).not.toThrow();
+		const aManifest = mergeManifests(bManifest, cManifest);
+
+		// D's ADT and instance each appear exactly once
+		expect(aManifest.adts.filter(x => x.name === 'Token')).toHaveLength(1);
+		expect(
+			aManifest.instances.filter(
+				x => x.traitName === 'Eq' && x.typeName === 'Token'
+			)
+		).toHaveLength(1);
+	});
+});

--- a/src/typer/module-manifest.ts
+++ b/src/typer/module-manifest.ts
@@ -1,0 +1,296 @@
+/**
+ * Module declaration manifest — the soundness core of the module system (Phase 1, Step 1).
+ *
+ * A `Manifest` is a pure, immutable description of the declarations a module
+ * (and its transitive imports) contributes to the global type environment:
+ *   - ADT definitions, each tagged with the canonical file path that defines them.
+ *   - Trait/constraint definitions, each tagged with their canonical defining path.
+ *   - `implement` instances, each tagged with (traitName, typeName, definingPath).
+ *
+ * `mergeManifests` is a pure set-union-with-conflict-detection:
+ *   - Commutative and associative.
+ *   - Deduplicates entries that are identical (same key AND same definingPath).
+ *   - Hard-errors on genuine conflicts (same logical key, different definingPath).
+ *   - Never re-validates instance bodies — trust/dedupe/conflict only.
+ *
+ * `validateOrphanRule` checks the weak orphan rule separately (can be called after merge).
+ *
+ * This module contains NO file I/O, NO type inference, and NO AST evaluation.
+ * It is intentionally self-contained so it can be unit-tested with synthetic data.
+ */
+
+// ─── public types ─────────────────────────────────────────────────────────────
+
+/**
+ * A single ADT (variant) definition in a manifest.
+ * Identity key: (definingPath, name).
+ */
+export type ManifestADT = {
+	/** The ADT's name, e.g. "Option", "Result". */
+	name: string;
+	/** Canonical real path of the file that defines this ADT. */
+	definingPath: string;
+	/** Ordered type parameter names, e.g. ["a"] for Option a. */
+	typeParams: string[];
+	/**
+	 * Constructor name → argument type descriptors.
+	 * Stored as an opaque Map; the merge function does NOT inspect or re-validate
+	 * the constructor types — it only compares identity keys.
+	 */
+	constructors: Map<string, unknown[]>;
+};
+
+/**
+ * A single `implement <Trait> <Type>` instance in a manifest.
+ * Identity key: (traitName, typeName).
+ * Dedup key: (traitName, typeName, definingPath) — same triple is a harmless diamond.
+ * Conflict: same (traitName, typeName) with two different definingPaths.
+ */
+export type ManifestInstance = {
+	traitName: string;
+	typeName: string;
+	/** Canonical real path of the file that defines this instance. */
+	definingPath: string;
+};
+
+/**
+ * A single trait/constraint definition in a manifest.
+ * Identity key: (definingPath, name).
+ * Conflict: same name, different definingPath.
+ */
+export type ManifestTraitDef = {
+	name: string;
+	definingPath: string;
+};
+
+/**
+ * The full declaration manifest for a module (and its transitive imports).
+ * Invariant: no two entries share the same identity key with different definingPaths.
+ */
+export type Manifest = {
+	adts: ManifestADT[];
+	instances: ManifestInstance[];
+	traitDefs: ManifestTraitDef[];
+};
+
+// ─── constructors ─────────────────────────────────────────────────────────────
+
+/** The empty manifest — identity element for mergeManifests. */
+export function emptyManifest(): Manifest {
+	return { adts: [], instances: [], traitDefs: [] };
+}
+
+// ─── merge ────────────────────────────────────────────────────────────────────
+
+/**
+ * Pure merge of two manifests.
+ *
+ * Properties:
+ *   - Commutative: mergeManifests(a, b) ≡ mergeManifests(b, a) (same logical result).
+ *   - Associative: mergeManifests(mergeManifests(a,b), c) ≡ mergeManifests(a, mergeManifests(b,c)).
+ *   - Conflict errors name BOTH conflicting paths, regardless of argument order.
+ *   - Never re-validates instance bodies.
+ *
+ * Throws a descriptive Error on:
+ *   - Two instances with the same (traitName, typeName) but different definingPaths.
+ *   - Two ADTs with the same name but different definingPaths.
+ *   - Two trait definitions with the same name but different definingPaths.
+ */
+export function mergeManifests(a: Manifest, b: Manifest): Manifest {
+	return {
+		adts: mergeADTs(a.adts, b.adts),
+		instances: mergeInstances(a.instances, b.instances),
+		traitDefs: mergeTraitDefs(a.traitDefs, b.traitDefs),
+	};
+}
+
+// ─── merge helpers ────────────────────────────────────────────────────────────
+
+function mergeInstances(
+	as: ManifestInstance[],
+	bs: ManifestInstance[]
+): ManifestInstance[] {
+	// Map keyed by "traitName\0typeName" → { definingPath, entry }
+	// Using a canonical separator that cannot appear in valid paths/names.
+	const seen = new Map<string, ManifestInstance>();
+
+	const add = (inst: ManifestInstance): void => {
+		const key = `${inst.traitName}\0${inst.typeName}`;
+		const existing = seen.get(key);
+		if (existing === undefined) {
+			seen.set(key, inst);
+		} else if (existing.definingPath === inst.definingPath) {
+			// Same (trait, type, path) — harmless diamond, dedupe silently.
+		} else {
+			// Same (trait, type), different paths — coherence conflict.
+			// Collect BOTH paths in the error, sorted so the message is
+			// deterministic regardless of argument order to mergeManifests.
+			const [pathA, pathB] = [existing.definingPath, inst.definingPath].sort();
+			throw new Error(
+				`Trait coherence conflict: both '${pathA}' and '${pathB}' define` +
+					` an instance of ${inst.traitName} for ${inst.typeName}.` +
+					` Only one implementation per (trait, type) pair is allowed.`
+			);
+		}
+	};
+
+	for (const inst of as) add(inst);
+	for (const inst of bs) add(inst);
+
+	return Array.from(seen.values());
+}
+
+function mergeADTs(as: ManifestADT[], bs: ManifestADT[]): ManifestADT[] {
+	// Key: "name" only — same name, different path is a conflict.
+	// Same name, same path is a dedupe.
+	const seen = new Map<string, ManifestADT>();
+
+	const add = (adt: ManifestADT): void => {
+		const existing = seen.get(adt.name);
+		if (existing === undefined) {
+			seen.set(adt.name, adt);
+		} else if (existing.definingPath === adt.definingPath) {
+			// Same (path, name) — dedupe silently.
+		} else {
+			const [pathA, pathB] = [existing.definingPath, adt.definingPath].sort();
+			throw new Error(
+				`ADT identity conflict: both '${pathA}' and '${pathB}' define` +
+					` a type named '${adt.name}'.` +
+					` Qualified coexistence is a Phase-3 namespacing feature.`
+			);
+		}
+	};
+
+	for (const adt of as) add(adt);
+	for (const adt of bs) add(adt);
+
+	return Array.from(seen.values());
+}
+
+function mergeTraitDefs(
+	as: ManifestTraitDef[],
+	bs: ManifestTraitDef[]
+): ManifestTraitDef[] {
+	const seen = new Map<string, ManifestTraitDef>();
+
+	const add = (td: ManifestTraitDef): void => {
+		const existing = seen.get(td.name);
+		if (existing === undefined) {
+			seen.set(td.name, td);
+		} else if (existing.definingPath === td.definingPath) {
+			// Same (path, name) — dedupe silently.
+		} else {
+			const [pathA, pathB] = [existing.definingPath, td.definingPath].sort();
+			throw new Error(
+				`Trait definition conflict: both '${pathA}' and '${pathB}' define` +
+					` a trait named '${td.name}'.`
+			);
+		}
+	};
+
+	for (const td of as) add(td);
+	for (const td of bs) add(td);
+
+	return Array.from(seen.values());
+}
+
+// ─── orphan rule ──────────────────────────────────────────────────────────────
+
+/**
+ * Validates the weak orphan rule across a (merged) manifest.
+ *
+ * Rule: an `implement Trait Type` instance must be defined in the same file as
+ * EITHER the trait definition OR the type (ADT) definition.
+ *
+ * Coherence unit exception: if all of (instance, traitDef, and ADT/type) have
+ * paths starting with "std/", they are treated as one coherence unit and no
+ * orphan error is raised. This lets stdlib modules implement traits/types from
+ * other stdlib modules.
+ *
+ * For primitive types (Float, String, Int, …) that have no ADT entry in the
+ * manifest, only the trait-co-location check applies.
+ *
+ * Throws with a message naming the offending instance's definingPath.
+ *
+ * Deferral note: the orphan rule for instances whose trait is not yet in the
+ * manifest (e.g. the trait comes from a separate import not yet merged) cannot
+ * be checked here. Callers must ensure the manifest is fully merged before
+ * calling this function.
+ */
+export function validateOrphanRule(manifest: Manifest): void {
+	const traitDefPaths = new Map<string, string>(); // traitName → definingPath
+	for (const td of manifest.traitDefs) {
+		traitDefPaths.set(td.name, td.definingPath);
+	}
+
+	const adtDefPaths = new Map<string, string>(); // typeName → definingPath
+	for (const adt of manifest.adts) {
+		adtDefPaths.set(adt.name, adt.definingPath);
+	}
+
+	for (const inst of manifest.instances) {
+		const traitPath = traitDefPaths.get(inst.traitName);
+		const typePath = adtDefPaths.get(inst.typeName);
+
+		if (isOrphan(inst.definingPath, traitPath, typePath)) {
+			throw new Error(
+				`Orphan instance: '${inst.definingPath}' defines` +
+					` \`implement ${inst.traitName} ${inst.typeName}\`` +
+					` but is not co-located with either the trait definition` +
+					(traitPath ? ` ('${traitPath}')` : ' (trait not in manifest)') +
+					` or the type definition` +
+					(typePath ? ` ('${typePath}')` : ' (primitive or not in manifest)') +
+					`. Move the instance to one of those files.`
+			);
+		}
+	}
+}
+
+/**
+ * Returns true if the instance at `instPath` is an orphan given where the
+ * trait and type are defined.
+ *
+ * Not an orphan if:
+ *   1. Instance is co-located with the trait (instPath === traitPath).
+ *   2. Instance is co-located with the type (instPath === typePath).
+ *   3. All of instance, trait, and type are in the std/* coherence unit.
+ *      (For primitives with no typePath, std coherence only applies if both
+ *       instance and trait are in std/*.)
+ */
+function isOrphan(
+	instPath: string,
+	traitPath: string | undefined,
+	typePath: string | undefined
+): boolean {
+	// Co-located with the trait
+	if (traitPath !== undefined && instPath === traitPath) return false;
+
+	// Co-located with the type
+	if (typePath !== undefined && instPath === typePath) return false;
+
+	// Std coherence unit: instance is std AND (trait is std OR type is std)
+	if (
+		isStdPath(instPath) &&
+		((traitPath !== undefined && isStdPath(traitPath)) ||
+			(typePath !== undefined && isStdPath(typePath)))
+	) {
+		return false;
+	}
+
+	return true;
+}
+
+/**
+ * Returns true if the path belongs to the std/* coherence unit.
+ * A path is "std" if it starts with "std/" (relative) or contains "/std/"
+ * as a directory component. This covers both the test convention (`std/foo.noo`)
+ * and real absolute paths (`.../stdlib/std/foo.noo`).
+ *
+ * Judgment call: the spec says "treat all of std/* as one coherence unit" but
+ * does not define what "std/*" means in terms of file paths. We use a liberal
+ * heuristic: any path component named "std" qualifies. If the stdlib ever moves,
+ * callers can pass normalised paths.
+ */
+function isStdPath(path: string): boolean {
+	return path.startsWith('std/') || path.includes('/std/');
+}


### PR DESCRIPTION
## Summary

- Adds `src/typer/module-manifest.ts`: a pure, self-contained `Manifest` type and `mergeManifests` / `validateOrphanRule` primitives — the soundness core for the module system (Phase 1, Step 1 from the plan).
- Adds 29 fail-closed unit tests in `src/typer/__tests__/module-manifest.test.ts` using synthetic in-memory manifests (no file I/O).
- No existing behaviour changed; all 1075 prior tests still pass; `tsc --noEmit` clean; `validate_examples.js` exits 0.

## Design choices

**`Manifest` shape**
```ts
type ManifestADT      = { name, definingPath, typeParams, constructors }
type ManifestInstance = { traitName, typeName, definingPath }
type ManifestTraitDef = { name, definingPath }
type Manifest         = { adts, instances, traitDefs }
```
All arrays; merge builds Maps internally, so the output order may differ between `merge(a,b)` and `merge(b,a)` but the logical content is identical (commutativity/associativity tested).

**Conflict detection**
- Instances keyed by `(traitName, typeName)`: same path → dedupe; different path → hard error naming **both** files (paths sorted before formatting so the message is order-independent).
- ADTs keyed by `name`: same path → dedupe; different path → hard error.
- Trait definitions: same treatment as ADTs.

**Orphan rule** (implemented best-effort, `validateOrphanRule` is a separate function):
- Not orphan if `inst.definingPath === traitDef.definingPath` (with the trait).
- Not orphan if `inst.definingPath === adt.definingPath` (with the type).
- Not orphan if instance + (trait or type) are all under `std/` (coherence unit).
- For primitives with no ADT entry, only the trait-co-location check applies.

**Judgment calls / ambiguities flagged for review**
1. **Trait def conflicts**: the spec explicitly states conflict rules for instances and ADTs. I applied the same "same name, different path → error" logic to trait definitions. This seems correct (two modules defining `constraint Eq …` at different paths would be incoherent) but is not spelled out.
2. **`isStdPath` heuristic**: the spec says "treat all of `std/*` as one coherence unit" without defining what constitutes `std/*` in terms of real paths. I treat any path starting with `std/` or containing `/std/` as std. This may need tightening once real path resolution is in place.
3. **Primitive types and orphan check**: for types like `Float` that have no ADT manifest entry, the orphan rule falls back to "must be with the trait". An instance for `Eq Float` in `std/eq.noo` (where `Eq` is also defined) passes; in `/userApp/extra.noo` it fails.
4. **`ManifestInstance` carries no implementation payload**: the merge function never inspects instance bodies (per spec: "never re-validate"). The payload can be added as an opaque field (`impl?: unknown`) when the loader wires manifests into `TypeState`; for now the type is minimal.

## Test → spec goal→proof mapping

| Spec guarantee | Test(s) | Kind |
|---|---|------|
| Trait coherence | "same (trait,type), two different definingPaths → throws"; "conflict error names BOTH files"; "conflict is order-independent" | fail-closed |
| Diamond safety | "D defines instance; merging via both paths gives one entry, no error" | positive |
| Type identity (ADT) | "same name, different definingPath → throws"; "ADT collision is order-independent" | fail-closed |
| Hermetic / commutativity | "merge(a,b) and merge(b,a) yield same result"; "associativity: merge(merge(a,b),c) ≡ merge(a,merge(b,c))" | property |
| Orphan rule | "orphan instance (neither with trait nor type, not std) → throws"; "std/* coherence unit not orphan"; "instance co-located with trait/type → not orphan" | fail-closed + positive |
| Dedupe (no false errors) | "same (trait,type,definingPath) merged twice → one entry"; "same ADT merged twice → one entry" | positive |

🤖 Generated with [Claude Code](https://claude.com/claude-code)