### PR TITLE
Docs: modules, Eq/Ord, effects, exhaustiveness, subset destructuring

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,10 +53,20 @@ the existing `Eq Float`/`Add String` wiring:
 - Unit is `{}` (not `()`). Records `{@field val}`, tuples `{a, b}`, lists `[a, b]`.
 - `/` and `%` return `Option Float` (safe division).
 - Record patterns in `match` bind a *subset* of fields; destructuring bindings
-  (`{@a} = r`) currently require an *exact* match. There is no variant
-  exhaustiveness checking yet (non-exhaustive `match` is accepted).
-- Effects are tracked in function types (`!write`, `!read`, `!log`, `!ffi`, …);
-  annotations may over-declare but must not omit an effect the body performs.
+  (`{@a} = r`) also bind a *subset* — naming a field the record lacks is a type
+  error.
+- A `match` on a concrete variant must cover every constructor or include a
+  catch-all (`_` wildcard or a bare variable); non-exhaustive matches are a type
+  error.
+- `<` `>` `<=` `>=` are polymorphic via an `Ord` constraint (Float, String);
+  `equals` / `==` are polymorphic via `Eq` (Float, String, Bool, Option,
+  Result, List).
+- Effects are tracked in function types (`!write`, `!read`, `!log`, `!ffi`, …)
+  and inferred automatically; annotations may over-declare but must not omit a
+  performed effect.
+- Module system: a `.noo` file's last expression is its exported value; relative
+  specifiers (`./`, `../`) are file-relative; bare specifiers resolve via
+  `noolang.json`; see `docs/language-reference.md` §Import System.
 
 ## Docs & CI
 

--- a/README.md
+++ b/README.md
@@ -918,12 +918,12 @@ Noolang provides a set of built-in functions organized by category:
 - **`%`** - Modulus: `Float -> Float -> Float`
 
 #### Comparison Operations (Pure)
-- **`==`** - Equality: `a -> a -> Bool` (polymorphic)
+- **`==`** / **`equals`** - Equality: `a -> a -> Bool given a implements Eq` — covers Float, String, Bool, Option, Result, List
 - **`!=`** - Inequality: `a -> a -> Bool` (polymorphic)
-- **`<`** - Less than: `Float -> Float -> Bool`
-- **`>`** - Greater than: `Float -> Float -> Bool`
-- **`<=`** - Less than or equal: `Float -> Float -> Bool`
-- **`>=`** - Greater than or equal: `Float -> Float -> Bool`
+- **`<`** - Less than: `a -> a -> Bool given a implements Ord` — Float, String
+- **`>`** - Greater than: `a -> a -> Bool given a implements Ord` — Float, String
+- **`<=`** - Less than or equal: `a -> a -> Bool given a implements Ord` — Float, String
+- **`>=`** - Greater than or equal: `a -> a -> Bool given a implements Ord` — Float, String
 
 #### Function Application and Composition (Pure)
 - **`|`** - Thrush operator (function application): `a -> (a -> b) -> b`

--- a/docs/language-reference.md
+++ b/docs/language-reference.md
@@ -442,6 +442,59 @@ person = { @name "Alice", @age 30, @city "NYC" };
 { @name "Alice", @age 30 };
 ```
 
+### Pattern Matching and Exhaustiveness
+
+`match expr (Pattern => branch; ...)` dispatches on a value. When the
+scrutinee has a concrete variant type (including built-ins like `Option`,
+`Result`, and `Bool`), every constructor must be covered or a catch-all must
+be present — otherwise the match is a **type error**.
+
+```noolang
+# Exhaustive match — all Option constructors covered
+unwrapOr = fn opt default => match opt (
+    Some x => x;
+    None => default
+);
+unwrapOr (Some 42.0) 0.0
+```
+
+```noolang
+# Wildcard catch-all satisfies exhaustiveness
+describe = fn opt => match opt (
+    Some x => "got " + show x;
+    _ => "nothing"
+);
+describe None
+```
+
+The following would be a type error (missing `None` case):
+
+```
+# TypeError: Non-exhaustive match on Option: missing case None.
+match (Some 1) (Some x => x)
+```
+
+A bare variable catch-all also works: `other => ...` matches anything not
+already covered and binds the value.
+
+### Destructuring Bindings
+
+Record destructuring binds a **subset** of fields — extra fields in the record
+are simply ignored. Only naming a field the record does not have is an error.
+
+```noolang
+# Bind just @a — @b is ignored
+rec = {@a 10.0, @b 20.0};
+{@a} = rec;
+a
+```
+
+```noolang
+# Rename on destructure
+{@name n, @age} = {@name "Alice", @age 30.0};
+n + " is " + show age
+```
+
 ## Type Names and Shadowing
 
 - Type names are global and cannot be redefined. Defining a `variant` or `type` with a name that already exists is a type error.
@@ -466,11 +519,77 @@ x = 5;  # End of line comment
 
 ## Import System
 
-```noolang
-# Import system is planned but not yet implemented
-# Currently all stdlib functions are available globally
-result = show 42;
+Noolang has a module system where each `.noo` file is a module. A module's
+**last expression** is its exported value — typically a record of named
+bindings.
+
 ```
+# math.noo — the last expression is the exported record
+addFn = fn x y => x + y;
+multiplyFn = fn x y => x * y;
+{@add addFn, @multiply multiplyFn}
+```
+
+### Importing modules
+
+Use `import "specifier"` to import another module.
+
+```
+# Import the whole module as a record
+math = import "./math";
+result = (@add math) 2 3;   # 5
+
+# Selective import via subset destructuring (recommended)
+{@add} = import "./math";
+result = add 2 3;           # 5
+
+# Rename while importing
+{@add myAdd} = import "./math";
+result = myAdd 2 3;         # 5
+```
+
+### Specifier rules
+
+| Form | Resolves to |
+|------|-------------|
+| `"./path"` or `"../path"` | File relative to the importing module |
+| `"bare-name"` or `"prefix/name"` | Entry in `noolang.json` import map |
+| `"std/*"` | Reserved for future stdlib modules (not yet importable) |
+
+Relative specifiers **must** begin with `./` or `../`. A bare specifier that
+has no matching import-map entry is a compile-time error.
+
+### Import map (`noolang.json`)
+
+Place a `noolang.json` at your project root to give short names to paths:
+
+```
+{
+  "imports": {
+    "math": "./lib/math",
+    "utils/": "./src/utils/"
+  }
+}
+```
+
+Then `import "math"` resolves to `./lib/math.noo` relative to the map file.
+
+### Rules and restrictions
+
+**Imports are pure.** A module may not perform top-level effects (`print`,
+`writeFile`, etc.). Doing so is a type error at import time. To share
+effectful operations, export an effect-typed function instead.
+
+**Circular imports error.** Because a module *is* its evaluated value,
+`A → B → A` is unresolvable. The error message includes the full cycle chain.
+
+**Coherence.** Only one `implement` block per `(Trait, Type)` pair is allowed
+across a program. Conflicting instances from different modules are an error.
+
+### Standard library
+
+All standard library functions (`map`, `filter`, `equals`, `show`, etc.) are
+loaded automatically at startup — you do not need to import them.
 
 ## Operator Precedence
 

--- a/docs/type-system.md
+++ b/docs/type-system.md
@@ -145,6 +145,80 @@ numberStrings = showAll [1, 2, 3];        # ["1", "2", "3"]
 boolStrings = showAll [True, False];      # ["True", "False"]
 ```
 
+#### Eq Constraint
+
+The `Eq` constraint enables equality comparison. `equals` and `==` work on
+Float, String, Bool, Option, Result, and List:
+
+```noolang
+# Eq for primitive types
+equals 1.0 1.0;          # True
+equals "hello" "world";  # False
+1.0 == 1.0;              # True
+"a" == "b";              # False
+```
+
+```noolang
+# Eq for Option, Result, List
+equals (Some 1.0) (Some 1.0);    # True
+equals None (Some 1.0);          # False
+equals (Ok 1.0) (Ok 1.0);        # True
+equals [1.0, 2.0] [1.0, 2.0];   # True
+```
+
+#### Ord Constraint
+
+The `Ord` constraint provides ordering operators `<`, `>`, `<=`, and `>=`.
+These are polymorphic over Float and String:
+
+```noolang
+# Ord for Float
+2.0 < 3.0;     # True
+3.0 > 2.0;     # True
+1.0 <= 1.0;    # True
+2.0 >= 1.0;    # True
+```
+
+```noolang
+# Ord for String (lexicographic)
+"a" < "b";     # True
+"b" > "a";     # True
+"abc" <= "abd"; # True
+```
+
+### Effect Inference and Enforcement
+
+Effects are automatically inferred into function types. A function that calls
+`print` or `println` gets effect `!write`; `readFile` adds `!read`; `log`
+adds `!log`, and so on. Effects propagate through function composition.
+
+```noolang
+# Effect is inferred — no annotation needed
+printTwice = fn x => (print x; print x);
+# Type: a -> a !write
+printTwice "hello"
+```
+
+When you add an explicit type annotation, it is **checked against the inferred
+effects**:
+
+- You **may** declare more effects than the body performs (over-declaration is
+  allowed for forward-compatibility).
+- You **must not** omit an effect the body actually performs.
+
+```noolang
+# Over-declaring is allowed — annotation adds !read even though body only writes
+verbose = fn x => print x : String -> String !write !read;
+verbose "ok"
+```
+
+The following would be a type error (annotation omits `!write`):
+
+```
+# TypeError: Type annotation omits effect !write performed by the expression
+bad = fn x => print x : String -> String;
+```
+
 ## Type System Integration
 
 ### Pipeline Operators


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: Fixed two stale quick-facts (exhaustiveness now enforced; destructuring now subset), added Eq/Ord/effect/module one-liners
- **docs/language-reference.md**: Replaced stub "import not yet implemented" with full Import System section; added Pattern Matching & Exhaustiveness and Destructuring Bindings sections with runnable examples
- **docs/type-system.md**: Added Eq/Ord constraint subsections and Effect Inference & Enforcement section, all with runnable examples
- **README.md**: Updated comparison operator table to show Ord/Eq polymorphism

## Runnable vs text-fenced examples

- Eq/Ord operators, exhaustiveness, subset destructuring, effect inference → `\`\`\`noolang\`` blocks (all verified against the interpreter)
- Module/import examples (multi-file by definition) → plain ` \`\`\` ` fences, same as existing import examples in README

## Validation

- `node validate_examples.js` exit 0
- `AGENT=1 bun test` 1136 pass / 0 fail (baseline unchanged)
- `bun run typecheck` clean

## Behaviors verified against interpreter

| Feature | Verified |
|---------|---------|
| `equals`/`==` on Float, String, Bool, Option, Result, List | ✓ |
| `<`/`>`/`<=`/`>=` on Float and String (Ord) | ✓ |
| Non-exhaustive match → TypeError | ✓ |
| Wildcard `_` / variable catch-all satisfies exhaustiveness | ✓ |
| `{@a} = {@a 1, @b 2}` binds subset | ✓ |
| Missing field in destructuring → type error | ✓ |
| Effect inferred into function type (`fn x => print x : a -> a !write`) | ✓ |
| Annotation omitting effect → TypeError | ✓ |
| Over-declaring effect → allowed | ✓ |
| Effectful top-level module → import error | ✓ |
| Circular imports → error with cycle chain | ✓ |
| Bare specifier without import map → error | ✓ |
| Import map (noolang.json) resolves bare specifiers | ✓ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)