### PR TITLE
Fix accessor structural constraints not resolving through higher-order functions

### DIFF
--- a/src/typer/__tests__/structural-constraints.test.ts
+++ b/src/typer/__tests__/structural-constraints.test.ts
@@ -148,7 +148,7 @@ describe('Structural Constraints', () => {
 			// Accessors in function bodies should work correctly
 		});
 
-		test.skip('Mapping accessors over lists', () => {
+		test('Mapping accessors over lists', () => {
 			const result = parseAndType(`map @name [{@name 'bob'}]`);
 			assertListType(result.type);
 			assertPrimitiveType(result.type.element);
@@ -191,7 +191,7 @@ describe('Structural Constraints', () => {
 			// expect(result.type.name).toBe('String'); // Should be this when fixed
 		});
 
-		test.skip('should work with accessor partial application', () => {
+		test('should work with accessor partial application', () => {
 			const result = parseAndType(`
         getName = @name;
         mapGetName = map getName;
@@ -199,11 +199,23 @@ describe('Structural Constraints', () => {
         result = mapGetName people
       `);
 			assertListType(result.type);
-			// TODO: Fix constraint propagation for accessors in higher-order functions
-			// Currently returns List a instead of List String
-			assertVariableType(result.type.element);
-			// assertPrimitiveType(result.type.element);
-			// expect(result.type.element.name).toBe('String'); // Should be this when fixed
+			// Accessor constraint now propagates through the higher-order map even
+			// when the accessor is let-bound and map is partially applied.
+			assertPrimitiveType(result.type.element);
+			expect(result.type.element.name).toBe('String');
+		});
+
+		test('let-bound accessor keeps return var linked to its field var', () => {
+			// Regression: instantiating a generalized accessor scheme used to
+			// decouple the return type variable from the field type variable inside
+			// its `has` constraint (`a -> b given a has {@name c}`), so the field
+			// type could never flow to the result. They must share one variable.
+			const result = parseAndType(`getName = @name; getName`);
+			const typeString = typeToString(
+				result.type,
+				result.state.substitution
+			);
+			expect(typeString).toBe('a -> b given a has {@name b}');
 		});
 	});
 

--- a/src/typer/constraint-resolution.ts
+++ b/src/typer/constraint-resolution.ts
@@ -64,6 +64,15 @@ export function tryResolveConstraints(
 	argTypes: Type[],
 	state: TypeState
 ): { resolvedType: Type; updatedState: TypeState } | null {
+	// Accumulate substitutions across ALL constraints before substituting the
+	// return type. A single application can carry several constraints (e.g.
+	// `map @name` has both `f implements Functor` and `b has {@name c}`);
+	// resolving only the first and returning early left the field type variable
+	// unbound, so `map @name [{@name "bob"}]` inferred `List a` instead of
+	// `List String`.
+	const mergedSubstitution = new Map(state.substitution);
+	let resolvedAny = false;
+
 	// For each constraint, check if any of the argument types can satisfy it
 	for (const constraint of functionConstraints) {
 		if (constraint.kind === 'implements') {
@@ -121,15 +130,11 @@ export function tryResolveConstraints(
 						substitution.set(varName, argType);
 					}
 
-					// Apply substitution to return type
-					const resolvedType = substitute(returnType, substitution);
-					// Merge the local substitution back into the global state
-					const updatedSubstitution = new Map([
-						...state.substitution,
-						...substitution,
-					]);
-					const updatedState = { ...state, substitution: updatedSubstitution };
-					return { resolvedType, updatedState };
+					// Accumulate this constraint's substitution and move on to the
+					// next constraint (do not substitute the return type yet).
+					for (const [k, v] of substitution) mergedSubstitution.set(k, v);
+					resolvedAny = true;
+					break;
 				}
 			}
 		} else if (constraint.kind === 'has') {
@@ -185,7 +190,7 @@ export function tryResolveConstraints(
 				if (actualRecordType) {
 					// Check if the record type has all required fields
 					let hasAllFields = true;
-					const substitution = new Map(state.substitution);
+					const substitution = new Map(mergedSubstitution);
 
 					for (const fieldName of Object.keys(requiredStructure.fields)) {
 						// Normalize field names - remove @ prefix if it exists
@@ -234,7 +239,8 @@ export function tryResolveConstraints(
 								}
 							}
 						}
-						// Apply substitution to return type
+						// Apply substitution to return type (used only by the special
+						// case below to detect an unsubstituted accessor return var).
 						let resolvedType = substitute(returnType, substitution);
 
 						// SPECIAL CASE: If the return type is still a variable and we have field type substitutions,
@@ -273,20 +279,25 @@ export function tryResolveConstraints(
 								resolvedType = resultType;
 							}
 						}
-						// Merge the local substitution back into the global state
-						const updatedSubstitution = new Map([
-							...state.substitution,
-							...substitution,
-						]);
-						const updatedState = {
-							...state,
-							substitution: updatedSubstitution,
-						};
-						return { resolvedType, updatedState };
+						// Reference resolvedType so it is not flagged as unused; the
+						// authoritative result comes from mergedSubstitution below.
+						void resolvedType;
+						// Accumulate this constraint's substitution and continue.
+						for (const [k, v] of substitution) mergedSubstitution.set(k, v);
+						resolvedAny = true;
+						break;
 					}
 				}
 			}
 		}
+	}
+
+	if (resolvedAny) {
+		const resolvedType = substitute(returnType, mergedSubstitution);
+		return {
+			resolvedType,
+			updatedState: { ...state, substitution: mergedSubstitution },
+		};
 	}
 
 	// Could not resolve any constraints

--- a/src/typer/type-operations.ts
+++ b/src/typer/type-operations.ts
@@ -6,6 +6,8 @@ import {
 	typeVariable,
 	type VariableType,
 	type Constraint,
+	type RecordStructure,
+	type StructureFieldType,
 } from '../ast';
 import { parse } from '../parser/parser';
 import { Lexer } from '../lexer/lexer';
@@ -185,28 +187,42 @@ export const freshenTypeVariables = (
 			);
 			
 			// Handle function-level constraints
+			currentState = finalState;
 			let newConstraints: Constraint[] | undefined = undefined;
 			if (type.constraints && type.constraints.length > 0) {
 				newConstraints = type.constraints.map(constraint => {
+					let updated: Constraint = constraint;
 					// Update constraint variable names using the mapping
 					if ('typeVar' in constraint) {
 						const mappedVar = mapping.get(constraint.typeVar);
 						if (mappedVar && mappedVar.kind === 'variable') {
-							return {
-								...constraint,
-								typeVar: mappedVar.name,
-							};
+							updated = { ...constraint, typeVar: mappedVar.name };
 						}
 					}
-					return constraint;
+					// Freshen the type variables INSIDE a structural constraint's
+					// structure so they stay linked to the (also freshened) return
+					// type. Without this, `getName = @name` instantiated to
+					// `a -> b given a has {@name c}` — the return `b` decoupled from
+					// the field var `c`, so `map getName xs` could never infer the
+					// element type.
+					if (updated.kind === 'has') {
+						const [freshStructure, nextState] = freshenRecordStructure(
+							updated.structure,
+							mapping,
+							currentState
+						);
+						currentState = nextState;
+						updated = { ...updated, structure: freshStructure };
+					}
+					return updated;
 				});
 			}
-			
+
 			const freshenedFunction = { ...type, params: newParams, return: newReturn };
 			if (newConstraints) {
 				freshenedFunction.constraints = newConstraints;
 			}
-			return [freshenedFunction, finalState];
+			return [freshenedFunction, currentState];
 		}
 		case 'list': {
 			const [newElem, nextState] = freshenTypeVariables(
@@ -301,6 +317,38 @@ export const freshenTypeVariables = (
 		default:
 			return [type, state];
 	}
+};
+
+// Freshen the type variables inside a structural-constraint RecordStructure,
+// reusing the same variable mapping as the enclosing type so field vars stay
+// linked to the freshened return type. Handles nested structures recursively.
+export const freshenRecordStructure = (
+	structure: RecordStructure,
+	mapping: Map<string, Type>,
+	state: TypeState
+): [RecordStructure, TypeState] => {
+	let currentState = state;
+	const newFields: { [fieldName: string]: StructureFieldType } = {};
+	for (const [fieldName, fieldType] of Object.entries(structure.fields)) {
+		if (fieldType.kind === 'nested') {
+			const [nested, nextState] = freshenRecordStructure(
+				fieldType.structure,
+				mapping,
+				currentState
+			);
+			currentState = nextState;
+			newFields[fieldName] = { kind: 'nested', structure: nested };
+		} else {
+			const [newField, nextState] = freshenTypeVariables(
+				fieldType,
+				mapping,
+				currentState
+			);
+			currentState = nextState;
+			newFields[fieldName] = newField;
+		}
+	}
+	return [{ fields: newFields }, currentState];
 };
 
 // Helper to flatten semicolon-separated binary expressions into individual statements


### PR DESCRIPTION
## Problem

`map @name [{@name "bob"}]` inferred `List a` instead of `List String`.

Nominal trait constraints already resolved through `map` — but only because their return types were already concrete (`show : a -> String`). An accessor's return *is* the field type variable, so it needs the `has` constraint to actually fire. It never did.

## Root causes

Two, independent.

**1. `constraint-resolution.ts` — first-constraint-wins short-circuit.**
`tryResolveConstraints` returned after the first satisfied constraint. For `map @name`, map's `f implements Functor` resolved and returned before the accessor's `b has {@name c}` could bind the field variable. Now accumulates substitutions from every constraint into one map, substitutes the return type once at the end.

**2. `type-operations.ts` — constraint variables decoupled at instantiation.**
`freshenTypeVariables` remapped a `has` constraint's `typeVar` but not the type variables *inside* `structure.fields`. Instantiating a generalized accessor scheme therefore split the return variable from the field variable:

```
getName = @name   →   a -> b given a has {@name c}    ← b and c unrelated
```

The field type could never reach the result. Adds `freshenRecordStructure` to freshen structure fields with the same variable mapping:

```
getName = @name   →   a -> b given a has {@name b}    ← linked
```

## Result

```
map @name [{@name "bob"}]                          List String   (was List a)
getName = @name; map getName [{@name "Alice"}]     List String   (was List a)
map @name [{@name "bob"}] | join ", "              String
```

## Tests

Unskips `Mapping accessors over lists` and `accessor partial application` (the latter asserted the broken `List a`; updated to `List String`). Adds a regression test pinning the return/field variable linkage.

Suite **1138 pass / 10 skip / 0 fail**. Typecheck clean. `validate_examples.js` exit 0.

## Still open (deeper, separate)

- Lambda-wrapped accessor: `map (fn p => @age p) xs` drops the `has` constraint entirely — lambda's constraint not lifted to function level for HOF collection.
- Chained nested accessor in a function: `fn p => getCity (getAddr p)` still returns a bare variable.
- `where`-expression constraint inference still stubbed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)