### PR TITLE
Lift accessor constraints from lambda parameters onto the function type

### DIFF
--- a/src/typer/__tests__/structural-constraints.test.ts
+++ b/src/typer/__tests__/structural-constraints.test.ts
@@ -155,6 +155,16 @@ describe('Structural Constraints', () => {
 			expect(result.type.element.name).toBe('String');
 		});
 
+		test('Mapping a lambda that wraps an accessor', () => {
+			// The accessor constraint is recorded on the lambda's PARAMETER variable;
+			// it must be lifted onto the lambda's function type or `map` drops it and
+			// the element type stays unresolved.
+			const result = parseAndType(`map (fn p => @age p) [{@age 3}]`);
+			assertListType(result.type);
+			assertPrimitiveType(result.type.element);
+			expect(result.type.element.name).toBe('Float');
+		});
+
 		test('should handle accessor with polymorphic return type', () => {
 			const result = parseAndType(`
         getValue = @value;

--- a/src/typer/type-inference.ts
+++ b/src/typer/type-inference.ts
@@ -64,6 +64,7 @@ import {
 	mapSet,
 	typeToString,
 	propagateConstraintToTypeVariable,
+	constraintsEqual,
 } from './helpers';
 import { unify } from './unify';
 import { substitute } from './substitute';
@@ -534,8 +535,50 @@ function buildNormalFunctionType(
 		funcType = functionType([paramTypes[i]], funcType, effects);
 	}
 
-	// Combine implicit constraints with body constraints
+	// Body inference attaches structural constraints straight to the parameter's
+	// type variable (`fn p => @age p` records `has {@age b}` on p's variable).
+	// Higher-order callers such as `map` collect constraints from the function
+	// TYPE, not from its parameter variables, so an unlifted constraint is simply
+	// dropped — `map (fn p => @age p) xs` inferred `List a`. Lift them, retargeted
+	// at the parameter's own variable so they cannot point at a stale
+	// pre-unification variable.
+	//
+	// Only lift a constraint whose field type IS this function's return variable.
+	// Such a constraint fully determines the result, so resolving it against a
+	// concrete argument yields the right type. A partial constraint must NOT be
+	// lifted: for `fn person => getCity (getAddress person)` the parameter only
+	// records `has {@address x}` (the chain through the let-bound accessors is not
+	// composed), and constraint resolution would then bind the bare return
+	// variable to the ADDRESS record rather than the city String — confidently
+	// wrong, where leaving it unresolved is merely incomplete.
+	const returnVarName = bodyType.kind === 'variable' ? bodyType.name : null;
+	const paramConstraints: Constraint[] = [];
+	if (returnVarName) {
+		for (const paramType of paramTypes) {
+			if (paramType.kind === 'variable' && paramType.constraints) {
+				for (const constraint of paramType.constraints) {
+					if (constraint.kind !== 'has') continue;
+					const determinesReturn = Object.values(
+						constraint.structure.fields
+					).some(
+						fieldType =>
+							fieldType.kind === 'variable' && fieldType.name === returnVarName
+					);
+					if (determinesReturn) {
+						paramConstraints.push({ ...constraint, typeVar: paramType.name });
+					}
+				}
+			}
+		}
+	}
+
+	// Combine implicit constraints with body and lifted parameter constraints
 	const allConstraints = [...implicitConstraints, ...bodyConstraints];
+	for (const constraint of paramConstraints) {
+		if (!allConstraints.some(existing => constraintsEqual(existing, constraint))) {
+			allConstraints.push(constraint);
+		}
+	}
 
 	// Apply constraints if we have any
 	if (allConstraints.length > 0 && funcType.kind === 'function') {


### PR DESCRIPTION
Follow-up to #121, same cluster.

## Problem

```
map (fn p => @age p) [{@age 3}]     →  List a     (want List Float)
```

`map @name xs` and `getName = @name; map getName xs` both work after #121. Wrapping the accessor in a lambda still dropped the constraint.

## Cause

Body inference attaches an accessor's structural constraint directly to the **parameter's type variable**. `generateDepthFirstConstraints` only recognises the composed `@outer (@inner param)` shape, so a plain `fn p => @age p` ends up with the constraint on the parameter variable and *nothing* on the function type.

Higher-order callers like `map` collect constraints from the function **type**, not from its parameter variables. So it was simply dropped.

`buildNormalFunctionType` now lifts such constraints onto the function type, retargeted at the parameter's own variable so they cannot point at a stale pre-unification variable.

## The restriction matters

Lifting is deliberately limited to constraints whose field type **is** the function's return variable. Those fully determine the result, so resolving them against a concrete argument gives the right type.

Lifting a *partial* constraint is actively harmful. For `fn person => getCity (getAddress person)` the parameter only records `has {@address x}` — the chain through the let-bound accessors is never composed — and constraint resolution would then bind the bare return variable to the **address record** rather than the city `String`. Confidently wrong, where leaving it unresolved is merely incomplete. An earlier revision of this patch did exactly that and broke two tests.

That case therefore still returns an unresolved variable, unchanged from before.

## Result

```
map (fn p => @age p) [{@age 3}]        List Float   (was List a)
f = fn p => @age p; map f [{@age 3}]   List Float   (was List a)
map @name [{@name "bob"}]              List String  (unchanged, #121)
```

Adds a regression test for the lambda-wrapped accessor.

Suite **1140 pass / 10 skip / 0 fail**. Typecheck clean. `validate_examples.js` exit 0.

## Still open in this cluster

- Chained nested accessor through let-bound accessors (`fn p => getCity (getAddress p)`) still yields a bare variable. Real fix is composing the constraint transitively; note `generateDepthFirstConstraints` also mints a *random* result variable disconnected from the body type (type-inference.ts), which needs sorting out first.
- `where`-expression constraint inference still stubbed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)