### PR TITLE
Constraint store: name-keyed structural constraints + freshen variable constraints

### DIFF
--- a/docs-wip/CONSTRAINT_STORE_DESIGN.md
+++ b/docs-wip/CONSTRAINT_STORE_DESIGN.md
@@ -1,0 +1,156 @@
+# Structural constraint store — design note
+
+Status: proposal. Written 2026-07-11, after PRs #121 and #122.
+
+## The goal
+
+Make chained accessors infer:
+
+```
+fn p => getCity (getAddress p)
+  want:  a -> b given a has {@address {@city b}}
+  today: a -> b            (constraint lost entirely)
+```
+
+And make the inline form stop lying:
+
+```
+fn obj => @name (@user obj)
+  want:  a -> b given a has {@user {@name b}}
+  today: a -> b given a has {@user {@name c}}     ← c is a RANDOM var, unrelated to b
+```
+
+## How structural constraints work today
+
+Three facts, each verified against the code:
+
+**1. Constraints live on type-variable objects, and propagate by mutation.**
+`typeAccessor` (`type-inference.ts:1337`) attaches a `has` constraint to the
+accessor's own parameter variable object. When the accessor is applied, `unify`
+merges that constraint into the argument's variable object
+(`unify.ts:466-472`). Propagation is therefore a side effect on a shared object,
+keyed by **object identity**, not by variable name.
+
+**2. `TypeState.constraints` is dead.** The field is declared
+(`types.ts:48`) and initialised to `[]` (`type-operations.ts:402,413`). Nothing
+ever writes to it or reads it. There is **no name-keyed constraint store**.
+
+**3. `constraint-composition.ts` is a dead module.** It exports
+`composeStructuralConstraints` (nests an outer constraint's structure into the
+inner constraint's connecting field) and `extractResultTypeVar` (finds the leaf
+variable). Both are correct. Both are unit-tested in isolation by
+`__tests__/constraint-composition.test.ts`. **Neither is imported by the typer.**
+
+Instead, `generateDepthFirstConstraints` (`type-inference.ts` ~L2008)
+reimplements composition — badly:
+
+- it pattern-matches only the *syntactic* shape `@outer (@inner param)`, so a
+  chain through let-bound accessors (`getCity (getAddress p)`) never composes at
+  all; and
+- it mints the result variable with `Math.random()`, so the composed
+  constraint's leaf is disconnected from the function's actual return variable.
+  That is the `c` in the "today" line above.
+
+## Why this is now actively fragile
+
+Identity-keyed propagation was survivable while nothing copied constraint
+structures. PR #121 added `freshenRecordStructure` (`type-operations.ts`), which
+deep-copies a constraint's field types on instantiation — correctly, to keep the
+leaf variable linked to the freshened return type. But it means a constraint's
+`α216` and the `α216` that `unify` later mutates can now be **different
+objects**. The scheme depends on an invariant that the code no longer maintains.
+
+This is the mechanism behind the chained-accessor failure: in
+`getCity (getAddress p)` the connecting variables end up **unbound**, and the
+return variable is never linked to the city field.
+
+## Proposed design
+
+Replace identity-keyed mutation with a name-keyed store, then wire the
+composition primitive that already exists.
+
+**1. Give `TypeState.constraints` a real type and use it.**
+
+```ts
+constraints: Map<string, Constraint[]>   // type-variable name -> its constraints
+```
+
+Resolve a variable's constraints by walking the substitution to the variable's
+representative name, then reading the map. Object-identity divergence stops
+mattering, because nothing depends on identity any more.
+
+**2. Record constraints by name.** `typeAccessor` registers
+`recordVar.name -> has {field: fieldVar}` in the store. `unify`, when binding
+variable `x := y`, unions `x`'s constraints into `y`'s entry (names, not
+objects).
+
+**3. Compose transitively at function-type construction.** For a parameter
+variable `P`, walk its constraint's fields; for a field whose type is a variable
+`V` that itself has a `has` constraint in the store, nest via the existing
+`composeStructuralConstraints`. Recurse. The leaf variable is then genuinely the
+body's result variable — no random var, and it works for let-bound chains
+because it follows the constraint graph rather than the syntax tree.
+
+**4. Delete `generateDepthFirstConstraints`.** Step 3 subsumes it. Its only
+reason to exist was the absence of a constraint graph to walk.
+
+**5. Keep the `buildNormalFunctionType` lift guard from #122** — a constraint is
+lifted onto the function type only when its leaf variable *is* the function's
+return variable. With real composition, `extractResultTypeVar` is exactly the
+predicate needed.
+
+## Migration — incremental, each step green
+
+The store can be introduced alongside the existing mechanism and cut over once,
+rather than in a big bang:
+
+1. Add the name-keyed store and populate it in `typeAccessor` and `unify`,
+   **without** removing the object-level constraints. Behaviour unchanged; assert
+   in tests that store and objects agree.
+2. Switch `buildNormalFunctionType`'s lift to read the store and compose via
+   `composeStructuralConstraints`. Chained accessors should start resolving.
+   Delete `generateDepthFirstConstraints`.
+3. Switch `constraint-resolution.ts` to read the store.
+4. Remove constraint mutation from `unify` and the `.constraints` field from
+   variable objects, once nothing reads them.
+
+Steps 3 and 4 are optional cleanup; the inference win lands at step 2.
+
+## Hazards
+
+**Constraint code goes green and wrong at the same time.** This area has no test
+coverage that defends correctness of the *inferred type* — only that inference
+does not crash. The first attempt at PR #122 lifted partial constraints and made
+`fn person => getCity (getAddress person)` infer the **address record** instead
+of the city `String`: a confidently wrong type where the prior behaviour was an
+honest unresolved variable. It was caught only because two pre-existing tests
+happened to pin the old shape.
+
+Rules:
+
+- **Prefer incomplete over incorrect.** `List a` is an acceptable outcome. A
+  wrong concrete type is not.
+- Never lift or resolve a *partial* structural constraint. Only a constraint
+  whose leaf variable is the function's return variable determines the result.
+  Note `findResultVariable` in `constraint-resolution.ts` binds a bare return
+  variable to the **first** substituted field variable — for a partial
+  constraint that is simply the wrong field. It is a trap; the composition work
+  should aim to retire it.
+- Verify by reading inferred types, not by watching the suite pass:
+  `NO_COLOR=1 bun src/cli.ts --types '<expr>'`.
+
+## Done means
+
+These probes, checked as type strings — not merely "tests pass":
+
+```
+fn obj => @name (@user obj)                        a -> b given a has {@user {@name b}}
+getAddr = @address; getCity = @city;
+  fn p => getCity (getAddr p)                      a -> b given a has {@address {@city b}}
+p = {@name "A", @address {@city "NYC"}};
+  getCity (getAddr p)                              String
+map @name [{@name "bob"}]                          List String     (must not regress, #121)
+map (fn p => @age p) [{@age 3}]                    List Float      (must not regress, #122)
+```
+
+Plus: suite green, `bun run typecheck` clean, `node validate_examples.js` exit 0.

--- a/src/module-loader.ts
+++ b/src/module-loader.ts
@@ -21,6 +21,7 @@ import type { Expression, Type } from './ast';
 import { flattenStatements } from './typer/type-operations';
 import { createTypeState, loadStdlib, generalize } from './typer/type-operations';
 import { substitute } from './typer/substitute';
+import { createConstraintStore } from './typer/constraint-store';
 import { initializeBuiltins } from './typer/builtins';
 import { typeExpression } from './typer/expression-dispatcher';
 import {
@@ -114,7 +115,7 @@ function cloneTypeStateForModule(base: TypeState): TypeState {
 		// This is what the "identical type across importers/orders" headline test
 		// exercises. The counter is never reset to a colliding fixed value.
 		counter: base.counter,
-		constraints: [],
+		constraints: createConstraintStore(),
 		adtRegistry,
 		traitRegistry,
 		protectedTypeNames: new Set(base.protectedTypeNames),

--- a/src/typer/constraint-store.ts
+++ b/src/typer/constraint-store.ts
@@ -1,0 +1,79 @@
+import type { Constraint, Type } from '../ast';
+import { constraintsEqual } from './helpers';
+
+/**
+ * Structural constraints keyed by type-variable NAME.
+ *
+ * The typer's original scheme hangs constraints off type-variable OBJECTS and
+ * propagates them by mutating those objects during unification
+ * (`unifyVariable`). That works only while every reference to a variable is the
+ * same object — an invariant the code no longer maintains: instantiation
+ * deep-copies constraint structures (`freshenRecordStructure`), so a
+ * constraint's `α216` and the `α216` that unification mutates can be different
+ * objects. Chained accessors lose their link that way.
+ *
+ * Keying by name, and resolving through the substitution, removes the
+ * dependency on object identity entirely.
+ *
+ * The store is persistent: every mutator returns a new map, matching how
+ * `TypeState.substitution` is threaded.
+ */
+export type ConstraintStore = Map<string, Constraint[]>;
+
+export const createConstraintStore = (): ConstraintStore => new Map();
+
+/**
+ * Follow the substitution to the variable's representative name.
+ *
+ * A variable bound to another variable shares its constraints; the last
+ * variable in the chain is the canonical key. A variable bound to a concrete
+ * type has no representative variable, so the chain stops at the last variable
+ * name — the caller decides what a concrete binding means.
+ */
+export const resolveVarName = (
+	name: string,
+	substitution: Map<string, Type>
+): string => {
+	let current = name;
+	const seen = new Set<string>();
+	while (!seen.has(current)) {
+		seen.add(current);
+		const next = substitution.get(current);
+		if (!next || next.kind !== 'variable') break;
+		current = next.name;
+	}
+	return current;
+};
+
+export const getConstraints = (
+	store: ConstraintStore,
+	varName: string,
+	substitution: Map<string, Type>
+): Constraint[] => store.get(resolveVarName(varName, substitution)) ?? [];
+
+export const addConstraint = (
+	store: ConstraintStore,
+	varName: string,
+	constraint: Constraint,
+	substitution: Map<string, Type>
+): ConstraintStore => {
+	const key = resolveVarName(varName, substitution);
+	const existing = store.get(key) ?? [];
+	if (existing.some(c => constraintsEqual(c, constraint))) return store;
+	const next = new Map(store);
+	next.set(key, [...existing, constraint]);
+	return next;
+};
+
+export const addConstraints = (
+	store: ConstraintStore,
+	varName: string,
+	constraints: Constraint[],
+	substitution: Map<string, Type>
+): ConstraintStore => {
+	let next = store;
+	for (const constraint of constraints) {
+		next = addConstraint(next, varName, constraint, substitution);
+	}
+	return next;
+};

--- a/src/typer/type-inference.ts
+++ b/src/typer/type-inference.ts
@@ -66,6 +66,7 @@ import {
 	propagateConstraintToTypeVariable,
 	constraintsEqual,
 } from './helpers';
+import { addConstraint } from './constraint-store';
 import { unify } from './unify';
 import { substitute } from './substitute';
 import { typeExpression } from './expression-dispatcher';
@@ -1334,6 +1335,7 @@ export const typeAccessor = (
 	const funcType = functionType([recordVar], returnType);
 	// Add structural constraint only for non-optional accessors.
 	// Optional accessors must NOT require the field to exist.
+	let stateWithConstraint = finalState;
 	if (!expr.optional && recordVar.kind === 'variable') {
 		// For validation: add to the type variable itself
 		recordVar.constraints = [
@@ -1348,9 +1350,23 @@ export const typeAccessor = (
 				fields: { [fieldName]: fieldType },
 			}),
 		];
+
+		// Name-keyed store: the authoritative record, independent of the object
+		// identity that the two assignments above depend on.
+		stateWithConstraint = {
+			...finalState,
+			constraints: addConstraint(
+				finalState.constraints,
+				recordVar.name,
+				hasStructureConstraint(recordVar.name, {
+					fields: { [fieldName]: fieldType },
+				}),
+				finalState.substitution
+			),
+		};
 	}
 
-	return createPureTypeResult(funcType, finalState);
+	return createPureTypeResult(funcType, stateWithConstraint);
 };
 
 // Type inference for tuples

--- a/src/typer/type-operations.ts
+++ b/src/typer/type-operations.ts
@@ -16,6 +16,7 @@ import { createTraitRegistry } from './trait-system';
 import { substitute } from './substitute';
 import { typeExpression } from './expression-dispatcher';
 import { constraintsEqual } from './helpers';
+import { createConstraintStore } from './constraint-store';
 
 // Fresh type variable generation - optimized to avoid string concatenation
 export const freshTypeVariable = (
@@ -149,22 +150,34 @@ export const freshenTypeVariables = (
 		case 'variable': {
 			const freshVar = mapping.get(type.name);
 			if (freshVar) {
-				// Copy constraints from the original variable to the fresh one
+				// Copy constraints from the original variable to the fresh one,
+				// FRESHENED. Copying them verbatim left them naming the SCHEME's
+				// variables, so an instantiated accessor's constraint still pointed at
+				// the scheme's field variable instead of this instantiation's. The
+				// chain in `getCity (getAddr p)` broke exactly there: the recorded
+				// constraint named a variable that nothing else in the program used.
+				let currentState = state;
 				if (freshVar.kind === 'variable') {
 					freshVar.constraints = freshVar.constraints || [];
 					if (type.constraints) {
 						for (const c of type.constraints) {
+							const [freshened, nextState] = freshenConstraint(
+								c,
+								mapping,
+								currentState
+							);
+							currentState = nextState;
 							if (
 								!freshVar.constraints.some(existing =>
-									constraintsEqual(existing, c)
+									constraintsEqual(existing, freshened)
 								)
 							) {
-								freshVar.constraints.push(c);
+								freshVar.constraints.push(freshened);
 							}
 						}
 					}
 				}
-				return [freshVar, state];
+				return [freshVar, currentState];
 			}
 			return [type, state];
 		}
@@ -191,30 +204,13 @@ export const freshenTypeVariables = (
 			let newConstraints: Constraint[] | undefined = undefined;
 			if (type.constraints && type.constraints.length > 0) {
 				newConstraints = type.constraints.map(constraint => {
-					let updated: Constraint = constraint;
-					// Update constraint variable names using the mapping
-					if ('typeVar' in constraint) {
-						const mappedVar = mapping.get(constraint.typeVar);
-						if (mappedVar && mappedVar.kind === 'variable') {
-							updated = { ...constraint, typeVar: mappedVar.name };
-						}
-					}
-					// Freshen the type variables INSIDE a structural constraint's
-					// structure so they stay linked to the (also freshened) return
-					// type. Without this, `getName = @name` instantiated to
-					// `a -> b given a has {@name c}` — the return `b` decoupled from
-					// the field var `c`, so `map getName xs` could never infer the
-					// element type.
-					if (updated.kind === 'has') {
-						const [freshStructure, nextState] = freshenRecordStructure(
-							updated.structure,
-							mapping,
-							currentState
-						);
-						currentState = nextState;
-						updated = { ...updated, structure: freshStructure };
-					}
-					return updated;
+					const [freshened, nextState] = freshenConstraint(
+						constraint,
+						mapping,
+						currentState
+					);
+					currentState = nextState;
+					return freshened;
 				});
 			}
 
@@ -319,6 +315,40 @@ export const freshenTypeVariables = (
 	}
 };
 
+/**
+ * Freshen a constraint against an instantiation's variable mapping: both the
+ * variable it constrains and the variables inside its structure.
+ *
+ * Both callers need this. Freshening only the `typeVar` leaves the structure
+ * naming the scheme's variables, which silently severs a constraint from the
+ * type it is supposed to describe.
+ */
+export const freshenConstraint = (
+	constraint: Constraint,
+	mapping: Map<string, Type>,
+	state: TypeState
+): [Constraint, TypeState] => {
+	let updated: Constraint = constraint;
+
+	if ('typeVar' in constraint) {
+		const mappedVar = mapping.get(constraint.typeVar);
+		if (mappedVar && mappedVar.kind === 'variable') {
+			updated = { ...constraint, typeVar: mappedVar.name };
+		}
+	}
+
+	if (updated.kind === 'has') {
+		const [freshStructure, nextState] = freshenRecordStructure(
+			updated.structure,
+			mapping,
+			state
+		);
+		return [{ ...updated, structure: freshStructure }, nextState];
+	}
+
+	return [updated, state];
+};
+
 // Freshen the type variables inside a structural-constraint RecordStructure,
 // reusing the same variable mapping as the enclosing type so field vars stay
 // linked to the freshened return type. Handles nested structures recursively.
@@ -399,7 +429,7 @@ export const createTypeState = (): TypeState => ({
 	environment: new Map(),
 	substitution: new Map(),
 	counter: 0,
-	constraints: [],
+	constraints: createConstraintStore(),
 	adtRegistry: new Map(),
 	traitRegistry: createTraitRegistry(), // NEW: Simple trait system
 	protectedTypeNames: new Set(),
@@ -410,7 +440,7 @@ export const createTypeState = (): TypeState => ({
 export const cleanSubstitutions = (state: TypeState): TypeState => ({
 	...state,
 	substitution: new Map(), // Clear substitutions but keep environment
-	constraints: [], // Clear constraints as well
+	constraints: createConstraintStore(), // Clear constraints as well
 });
 
 // Centralized reserved type names (cannot be shadowed by user-defined types or variants)

--- a/src/typer/types.ts
+++ b/src/typer/types.ts
@@ -1,5 +1,6 @@
 import type { Constraint, Type, Effect } from '../ast';
 import type { TraitRegistry } from './trait-system';
+import type { ConstraintStore } from './constraint-store';
 
 // ADT registry for tracking defined algebraic data types
 export type ADTRegistry = Map<
@@ -45,7 +46,12 @@ export type TypeState = {
 	environment: TypeEnvironment;
 	substitution: Map<string, Type>;
 	counter: number;
-	constraints: Constraint[]; // Track constraints during inference
+	/**
+	 * Structural constraints keyed by type-variable name. See constraint-store.ts
+	 * for why name-keyed rather than hung off variable objects. Replaces a
+	 * `Constraint[]` field that was declared, initialised, and never used.
+	 */
+	constraints: ConstraintStore;
 	adtRegistry: ADTRegistry; // Track ADT definitions
 	traitRegistry: TraitRegistry;
 	protectedTypeNames: Set<string>; // Names of types reserved/protected from shadowing

--- a/src/typer/unify.ts
+++ b/src/typer/unify.ts
@@ -9,6 +9,7 @@ import {
 	unificationError,
 } from './type-errors';
 import { mapSet, typeToString, occursIn } from './helpers';
+import { addConstraints, getConstraints } from './constraint-store';
 // Legacy constraint imports removed
 import { functionApplicationError } from './type-errors';
 import { getTypeName } from './trait-system';
@@ -487,9 +488,35 @@ function unifyVariable(
 				)
 			)
 		);
+	const newSubstitution = mapSet(state.substitution, s1.name, s2);
+
+	// Carry s1's constraints over to s2 in the name-keyed store, mirroring the
+	// object-level merge above. Binding s1 := s2 makes s2 the representative, so
+	// s1's constraints become s2's. Constraints already recorded against s1's own
+	// name are included: the object-level chain walk above only sees constraints
+	// that happen to hang off the variable OBJECTS it can reach.
+	let newConstraints = state.constraints;
+	// Read s1's entry against the OLD substitution: under the new one s1 already
+	// resolves to s2, which would hand back s2's own constraints instead.
+	const storedForS1 = getConstraints(
+		state.constraints,
+		s1.name,
+		state.substitution
+	);
+	const carried = [...constraintsToCheck, ...storedForS1];
+	if (isTypeKind(s2, 'variable') && carried.length > 0) {
+		newConstraints = addConstraints(
+			newConstraints,
+			s2.name,
+			carried,
+			newSubstitution
+		);
+	}
+
 	let newState = {
 		...state,
-		substitution: mapSet(state.substitution, s1.name, s2),
+		substitution: newSubstitution,
+		constraints: newConstraints,
 	};
 	// If s2 is not a variable, propagate or check constraints
 	if (!isTypeKind(s2, 'variable')) {


### PR DESCRIPTION
**Stacked PR 1 of 2.** Groundwork only — no inference results change here. PR 2 builds on this and lands the actual win.

Design note: [`docs-wip/CONSTRAINT_STORE_DESIGN.md`](docs-wip/CONSTRAINT_STORE_DESIGN.md).

## Why

Structural constraints were hung off type-variable **objects** and propagated by **mutating** those objects during unification (`unify.ts:466`). That works only while every reference to a variable is the same object — an invariant the code stopped maintaining when #121 added `freshenRecordStructure`, which deep-copies constraint structures on instantiation.

## What

**1. `TypeState.constraints` becomes a real store.** `Map<varName, Constraint[]>`, resolved through the substitution, so object identity stops mattering. The field already existed as a `Constraint[]` — declared, initialised in three places, and **never read or written**. It now earns its keep.

Populated in `typeAccessor` and `unifyVariable`, *alongside* the existing object-level mechanism rather than replacing it. The old path still drives inference, so results are unchanged. Cutover happens in PR 2.

**2. Fixes a real staleness bug** found while wiring it up. `freshenTypeVariables` freshened a **function's** constraints but copied a **variable's** constraints verbatim, leaving them naming the *scheme's* variables rather than the instantiation's. An instantiated accessor's constraint therefore pointed at a variable nothing else in the program used — precisely where the chain in `getCity (getAddr p)` was severed. Both call sites now share a `freshenConstraint` helper.

## Effect

The chain is now intact and, as a side effect, visible:

```
getAddr = @address; getCity = @city; fn p => getCity (getAddr p)

before:  a -> b
after:   a -> b given a has {@address c given d has {@city b}}
```

The leaf **is** the return variable `b`. Composing that into `a has {@address {@city b}}` and resolving it is PR 2.

## Also worth knowing

`constraint-composition.ts` — which exports a correct `composeStructuralConstraints` and `extractResultTypeVar`, and is unit-tested — **is never imported by the typer**. Dead module. Meanwhile `generateDepthFirstConstraints` reimplements composition badly, matching only the syntactic shape `@outer (@inner param)` and minting its result variable with `Math.random()`. PR 2 wires up the real one and deletes the impostor.

## Verification

Suite **1140 pass / 10 skip / 0 fail**. Typecheck clean. `validate_examples.js` exit 0. Existing accessor inference unchanged:

```
map @name [{@name "bob"}]         List String
map (fn p => @age p) [{@age 3}]   List Float
getName = @name; getName          a -> b given a has {@name b}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)