### PR TITLE
Compose chained accessor constraints from the store

### DIFF
--- a/src/typer/__tests__/structural-constraints.test.ts
+++ b/src/typer/__tests__/structural-constraints.test.ts
@@ -194,11 +194,35 @@ describe('Structural Constraints', () => {
           @address {@street "123 Main", @city "NYC"}
         }
       `);
-			// TODO: Fix constraint resolution for chained accessor function calls
-			// Currently returns a type variable instead of String
-			assertVariableType(result.type);
-			// assertPrimitiveType(result.type);
-			// expect(result.type.name).toBe('String'); // Should be this when fixed
+			// The chain composes out of the constraint store, so the city field type
+			// now reaches the result instead of stalling as a type variable.
+			assertPrimitiveType(result.type);
+			expect(result.type.name).toBe('String');
+		});
+
+		test('chained accessors compose into a nested constraint (let-bound)', () => {
+			// Follows the constraint GRAPH, so a chain through let-bound accessors
+			// composes the same as an inline one. The leaf must be the function's own
+			// return variable: a composed constraint whose leaf is some unrelated
+			// variable cannot resolve, and one that names the WRONG field resolves to
+			// a confidently wrong type.
+			const result = parseAndType(
+				`getAddr = @address; getCity = @city; fn p => getCity (getAddr p)`
+			);
+			expect(typeToString(result.type, result.state.substitution)).toBe(
+				'a -> b given a has {@address {@city b}}'
+			);
+		});
+
+		test('inline chained accessors compose without inventing a variable', () => {
+			// Regression: composition used to be derived syntactically and minted its
+			// result variable with Math.random(), so the constraint's leaf was
+			// disconnected from the return type — it read `{@name c}` against a
+			// return of `b`.
+			const result = parseAndType(`fn obj => @name (@user obj)`);
+			expect(typeToString(result.type, result.state.substitution)).toBe(
+				'a -> b given a has {@user {@name b}}'
+			);
 		});
 
 		test('should work with accessor partial application', () => {

--- a/src/typer/constraint-composition.ts
+++ b/src/typer/constraint-composition.ts
@@ -2,7 +2,13 @@ import {
 	hasStructureConstraint,
 	type HasStructureConstraint,
 	type StructureFieldType,
+	type Type,
 } from '../ast';
+import {
+	getConstraints,
+	resolveVarName,
+	type ConstraintStore,
+} from './constraint-store';
 
 /**
  * Compose two structural constraints to create a nested constraint.
@@ -57,6 +63,56 @@ export function composeStructuralConstraints(
 	return hasStructureConstraint(innerConstraint.typeVar, {
 		fields: composedFields,
 	});
+}
+
+/**
+ * Fold a variable's structural constraints, and those of the variables its
+ * fields point at, into a single nested constraint.
+ *
+ * `getCity (getAddress p)` records two separate links — `p has {@address x}`
+ * and `x has {@city y}` — because each accessor constrains its own argument.
+ * Walking that graph and nesting each field's own constraint into its position
+ * yields `p has {@address {@city y}}`, with `y` still the variable the body
+ * actually returns.
+ *
+ * Follows the constraint GRAPH, not the syntax tree, so a chain through
+ * let-bound accessors composes exactly like an inline one.
+ *
+ * Returns null when the variable has no structural constraint. `seen` guards
+ * against a cyclic constraint graph.
+ */
+export function composeConstraintChain(
+	varName: string,
+	store: ConstraintStore,
+	substitution: Map<string, Type>,
+	seen: Set<string> = new Set()
+): HasStructureConstraint | null {
+	const key = resolveVarName(varName, substitution);
+	if (seen.has(key)) return null;
+
+	const base = getConstraints(store, key, substitution).find(
+		(c): c is HasStructureConstraint => c.kind === 'has'
+	);
+	if (!base) return null;
+
+	const nextSeen = new Set(seen).add(key);
+	let composed: HasStructureConstraint = hasStructureConstraint(key, {
+		fields: { ...base.structure.fields },
+	});
+
+	for (const [, fieldType] of Object.entries(base.structure.fields)) {
+		if (fieldType.kind !== 'variable') continue;
+		const nested = composeConstraintChain(
+			fieldType.name,
+			store,
+			substitution,
+			nextSeen
+		);
+		if (!nested) continue;
+		composed = composeStructuralConstraints(composed, nested, fieldType.name);
+	}
+
+	return composed;
 }
 
 /**

--- a/src/typer/type-inference.ts
+++ b/src/typer/type-inference.ts
@@ -66,7 +66,11 @@ import {
 	propagateConstraintToTypeVariable,
 	constraintsEqual,
 } from './helpers';
-import { addConstraint } from './constraint-store';
+import { addConstraint, resolveVarName } from './constraint-store';
+import {
+	composeConstraintChain,
+	extractResultTypeVar,
+} from './constraint-composition';
 import { unify } from './unify';
 import { substitute } from './substitute';
 import { typeExpression } from './expression-dispatcher';
@@ -502,7 +506,8 @@ function handleConstrainedFunctionBody(
 function buildNormalFunctionType(
 	paramTypes: Type[],
 	bodyResult: TypeResult,
-	implicitConstraints: Constraint[]
+	implicitConstraints: Constraint[],
+	state: TypeState
 ): Type {
 	// Extract constraints from the body result type if it's constrained
 	const bodyConstraints: Constraint[] = [];
@@ -536,39 +541,42 @@ function buildNormalFunctionType(
 		funcType = functionType([paramTypes[i]], funcType, effects);
 	}
 
-	// Body inference attaches structural constraints straight to the parameter's
-	// type variable (`fn p => @age p` records `has {@age b}` on p's variable).
-	// Higher-order callers such as `map` collect constraints from the function
-	// TYPE, not from its parameter variables, so an unlifted constraint is simply
-	// dropped — `map (fn p => @age p) xs` inferred `List a`. Lift them, retargeted
-	// at the parameter's own variable so they cannot point at a stale
-	// pre-unification variable.
+	// Body inference records an accessor's structural constraint against the
+	// ARGUMENT it constrains — so `fn p => @age p` records `p has {@age b}`, and
+	// `fn p => getCity (getAddr p)` records two separate links, `p has {@address
+	// x}` and `x has {@city b}`. Higher-order callers such as `map` read
+	// constraints from the function TYPE, not from the store, so anything not
+	// lifted onto the type is simply dropped.
 	//
-	// Only lift a constraint whose field type IS this function's return variable.
-	// Such a constraint fully determines the result, so resolving it against a
-	// concrete argument yields the right type. A partial constraint must NOT be
-	// lifted: for `fn person => getCity (getAddress person)` the parameter only
-	// records `has {@address x}` (the chain through the let-bound accessors is not
-	// composed), and constraint resolution would then bind the bare return
-	// variable to the ADDRESS record rather than the city String — confidently
-	// wrong, where leaving it unresolved is merely incomplete.
+	// Compose each parameter's chain out of the store (following the constraint
+	// graph, so a chain through let-bound accessors folds up exactly like an
+	// inline one), then lift it.
+	//
+	// Lift ONLY when the composed constraint's leaf variable IS this function's
+	// return variable. Such a constraint fully determines the result, so resolving
+	// it against a concrete argument yields the right type. Lifting a constraint
+	// that does NOT determine the return is actively harmful: constraint
+	// resolution binds a bare return variable to the FIRST substituted field
+	// variable, which for a partial constraint is the wrong field — it made
+	// `fn person => getCity (getAddress person)` infer the ADDRESS RECORD rather
+	// than the city String. Confidently wrong beats honestly unresolved only in
+	// the sense that it is worse.
 	const returnVarName = bodyType.kind === 'variable' ? bodyType.name : null;
 	const paramConstraints: Constraint[] = [];
 	if (returnVarName) {
 		for (const paramType of paramTypes) {
-			if (paramType.kind === 'variable' && paramType.constraints) {
-				for (const constraint of paramType.constraints) {
-					if (constraint.kind !== 'has') continue;
-					const determinesReturn = Object.values(
-						constraint.structure.fields
-					).some(
-						fieldType =>
-							fieldType.kind === 'variable' && fieldType.name === returnVarName
-					);
-					if (determinesReturn) {
-						paramConstraints.push({ ...constraint, typeVar: paramType.name });
-					}
-				}
+			if (paramType.kind !== 'variable') continue;
+			const composed = composeConstraintChain(
+				paramType.name,
+				state.constraints,
+				state.substitution
+			);
+			if (!composed) continue;
+			if (
+				extractResultTypeVar(composed) ===
+				resolveVarName(returnVarName, state.substitution)
+			) {
+				paramConstraints.push({ ...composed, typeVar: paramType.name });
 			}
 		}
 	}
@@ -626,7 +634,8 @@ export const typeFunction = (
 			: buildNormalFunctionType(
 					substitutedParamTypes,
 					bodyResult,
-					implicitConstraints
+					implicitConstraints,
+					currentState
 				);
 
 	// The latent effects now live on the function type (see
@@ -663,15 +672,10 @@ function collectImplicitConstraints(
 		}
 	}
 
-	// DEPTH-FIRST: Generate structural constraints inline with unified variables
-	if (bodyExpr && paramNames) {
-		const structuralConstraints = generateDepthFirstConstraints(
-			bodyExpr,
-			paramNames,
-			paramTypes
-		);
-		constraints.push(...structuralConstraints);
-	}
+	// Structural constraints are no longer derived from the syntax here.
+	// buildNormalFunctionType composes them out of the constraint store, which
+	// follows the constraint graph and therefore handles let-bound chains that no
+	// syntactic pattern could see.
 
 	return constraints;
 }
@@ -2023,77 +2027,3 @@ export const typeRecordDestructuring = (
 };
 
 // DEPTH-FIRST constraint generation - replaces collectAccessorConstraints
-function generateDepthFirstConstraints(
-	expr: Expression,
-	paramNames: string[],
-	paramTypes: Type[]
-): Constraint[] {
-	const constraints: Constraint[] = [];
-
-	// Create mapping from parameter names to their type variables
-	const paramTypeVars = new Map<string, string>();
-	for (let i = 0; i < paramNames.length && i < paramTypes.length; i++) {
-		const paramType = paramTypes[i];
-		if (paramType.kind === 'variable') {
-			paramTypeVars.set(paramNames[i], paramType.name);
-		}
-	}
-
-	// Analyze expression for accessor composition patterns
-	function analyzeExpression(e: Expression): void {
-		if (!e) return;
-
-		if (
-			e.kind === 'application' &&
-			e.func.kind === 'accessor' &&
-			e.args.length === 1
-		) {
-			const outerField = e.func.field;
-			const innerArg = e.args[0];
-
-			// Check for composition: @outer (@inner param)
-			if (
-				innerArg.kind === 'application' &&
-				innerArg.func.kind === 'accessor' &&
-				innerArg.args.length === 1 &&
-				innerArg.args[0].kind === 'variable' &&
-				paramTypeVars.has(innerArg.args[0].name)
-			) {
-				const innerField = innerArg.func.field;
-				const paramName = innerArg.args[0].name;
-				const paramTypeVar = paramTypeVars.get(paramName)!;
-
-				// Generate multiplicative constraint directly
-				const resultVar = `α${Math.random().toString(36).substr(2, 9)}`;
-				const composedConstraint = hasStructureConstraint(paramTypeVar, {
-					fields: {
-						[innerField]: {
-							kind: 'nested',
-							structure: {
-								fields: {
-									[outerField]: { kind: 'variable', name: resultVar },
-								},
-							},
-						},
-					},
-				});
-
-				constraints.push(composedConstraint);
-				return; // Don't recurse - we handled the composition
-			}
-		}
-
-		// Recurse into sub-expressions for other cases
-		if (e.kind === 'application') {
-			analyzeExpression(e.func);
-			e.args.forEach(analyzeExpression);
-		} else if (e.kind === 'binary') {
-			analyzeExpression(e.left);
-			analyzeExpression(e.right);
-		}
-		// Add other cases as needed
-	}
-
-	analyzeExpression(expr);
-	return constraints;
-}


### PR DESCRIPTION
**Stacked PR 2 of 2.** Targets `feat/constraint-store` (#123) — review that one first; this diff is only the composition layer. Merging #123 will retarget this to `main`.

## Result

```
getAddr = @address; getCity = @city; fn p => getCity (getAddr p)
  before:  a -> b                                  ← constraint lost entirely
  after:   a -> b given a has {@address {@city b}}

…applied to a concrete record
  before:  a
  after:   String
```

And the inline form stops inventing a variable:

```
fn obj => @name (@user obj)
  before:  a -> b given a has {@user {@name c}}    ← c was Math.random()
  after:   a -> b given a has {@user {@name b}}
```

## How

**Wires up `constraint-composition.ts`, dead since the day it was written.** It exports a correct `composeStructuralConstraints` and `extractResultTypeVar`, it is unit-tested — and it was never imported by the typer.

Adds `composeConstraintChain`, which folds a variable's constraints, and those of the variables its fields point at, into one nested constraint by walking the constraint **graph** out of the store (#123). A chain through let-bound accessors composes exactly like an inline one, because the graph doesn't care how the chain was spelled. No syntactic pattern could see the let-bound form at all.

**Deletes `generateDepthFirstConstraints`**, which reimplemented composition by pattern-matching the literal shape `@outer (@inner param)` and minting its result variable with `Math.random()` — hence the disconnected `c` above.

## The guard is load-bearing

`buildNormalFunctionType` lifts a composed constraint only when its leaf variable **is** the function's return variable. `extractResultTypeVar` is exactly that predicate.

This is not caution. Constraint resolution binds a bare return variable to the *first* substituted field variable, so lifting a constraint that does not determine the return infers **the wrong field's type**. That is what made an earlier revision of #122 report the address record where the city `String` belonged. Do not loosen it.

## Verification

This area goes green and wrong easily, so I checked inferred types directly, not just the suite:

| probe | result |
|---|---|
| `fn p => (@age p) + 1` (partial constraint — must not lift) | `a -> Float given a has {@age b}` ✅ |
| `getCity {@name "A"}` (missing field) | still errors ✅ |
| chained access, inner field missing | still errors ✅ |
| `@name? {@x 1}` (optional accessor) | `Option a`, unaffected ✅ |
| three-deep chain `c (b (a p))` | evaluates to `42` ✅ |
| `map @name [{@name "bob"}]` | `List String`, no regression ✅ |
| `map (fn p => @age p) [{@age 3}]` | `List Float`, no regression ✅ |

Suite **1142 pass / 10 skip / 0 fail**. Typecheck clean. `validate_examples.js` exit 0.

Closes the chained-accessor item in [`docs-wip/CONSTRAINT_STORE_DESIGN.md`](docs-wip/CONSTRAINT_STORE_DESIGN.md). Steps 3–4 there (moving `constraint-resolution` onto the store, then retiring the object-level constraints and `findResultVariable`) remain optional cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)