### PR TITLE
Stop leaking internal type-variable names from accessor errors

### DIFF
--- a/src/typer/__tests__/structural-constraints.test.ts
+++ b/src/typer/__tests__/structural-constraints.test.ts
@@ -365,3 +365,40 @@ describe('Pipeline Operator Composition', () => {
 		expect(userRecord.fields.age.name).toBe('Float');
 	});
 });
+
+describe('Accessor error messages', () => {
+	// These errors are what a user sees when field access goes wrong. They used to
+	// read `constraint α223 has {@city}` — an internal type-variable name, which
+	// means nothing to anyone outside the typer.
+	const messageFor = (code: string): string => {
+		try {
+			parseAndType(code);
+		} catch (e) {
+			return e instanceof Error ? e.message : String(e);
+		}
+		throw new Error(`Expected ${code} to fail type checking`);
+	};
+
+	test('never leaks an internal type-variable name', () => {
+		const messages = [
+			messageFor(`getAddr = @address; getAddr 1`),
+			messageFor(`getCity = @city; getCity {@name "A"}`),
+		];
+		for (const message of messages) {
+			expect(message).not.toMatch(/α\d+/);
+			expect(message).not.toMatch(/constraint \w+ has/);
+		}
+	});
+
+	test('names the offending type when the target is not a record', () => {
+		const message = messageFor(`getAddr = @address; getAddr 1`);
+		expect(message).toMatch(/Cannot access @address on Float/);
+	});
+
+	test('lists the fields the record does have', () => {
+		const message = messageFor(`getCity = @city; getCity {@name "A", @age 3}`);
+		expect(message).toMatch(/Record has no field @city/);
+		expect(message).toMatch(/@name/);
+		expect(message).toMatch(/@age/);
+	});
+});

--- a/src/typer/unify.ts
+++ b/src/typer/unify.ts
@@ -535,12 +535,23 @@ function unifyVariable(
 						constraint.structure.fields
 					)) {
 						if (!(fieldName in s2.fields)) {
+							const present = Object.keys(s2.fields).map(f => `@${f}`);
 							throw new Error(
-								`Record missing required field @${fieldName} for constraint ${constraint.typeVar} has {${Object.keys(
-									constraint.structure.fields
+								formatTypeError(
+									createTypeError(
+										`Record has no field @${fieldName}`,
+										{
+											actualType: s2,
+											suggestion:
+												present.length > 0
+													? `This record has ${present.join(
+															', '
+														)}. Check the field name.`
+													: `This record has no fields.`,
+										},
+										location || { line: 1, column: 1 }
+									)
 								)
-									.map(f => `@${f}`)
-									.join(', ')}}`
 							);
 						}
 
@@ -574,7 +585,19 @@ function unifyVariable(
 						.map(f => `@${f}`)
 						.join(', ');
 					throw new Error(
-						`Type ${s2.kind === 'primitive' ? s2.name : s2.kind} cannot satisfy constraint ${constraint.typeVar} has {${fieldNames}} - expected a record type`
+						formatTypeError(
+							createTypeError(
+								`Cannot access ${fieldNames} on ${typeToString(
+									s2,
+									state.substitution
+								)}`,
+								{
+									actualType: s2,
+									suggestion: `Field access requires a record with ${fieldNames}.`,
+								},
+								location || { line: 1, column: 1 }
+							)
+						)
 					);
 				}
 			} else if (constraint.kind === 'is') {

--- a/test/language-features/destructuring.test.ts
+++ b/test/language-features/destructuring.test.ts
@@ -101,7 +101,7 @@ test('should throw error for missing fields in record destructuring', () => {
 	// Destructuring binds a subset of a record's fields, but naming a field the
 	// record does not have is still rejected (now at type-check time).
 	const source = '{@name, @missing} = {@name "Test"}';
-	expect(() => runCode(source)).toThrow(/missing required field @missing/);
+	expect(() => runCode(source)).toThrow(/Record has no field @missing/);
 });
 
 test('should throw error for tuple length mismatch', () => {


### PR DESCRIPTION
**Stacked PR 3.** Targets #124. Independent of the constraint work — it's the papercut that surfaced while testing it.

## Before

```
Type Float cannot satisfy constraint α223 has {@city} - expected a record type
Record missing required field @city for constraint α223 has {@city}
```

`α223` is an internal type-variable name. It means nothing to a user. Both messages also bypassed `formatTypeError`, so they carried no source location and looked nothing like every other type error in the language.

## After

```
TypeError: Cannot access @address on Float
  at line 1, column 21

💡 Field access requires a record with @address.
```

```
TypeError: Record has no field @city
  at line 1, column 18

💡 This record has @name, @age. Check the field name.
```

Names the offending type, lists the fields the record *does* have, and routes through `createTypeError`/`formatTypeError` like everything else.

## Tests

Pin the **properties**, not the prose — so rewording later doesn't churn the tests:

- no `α\d+` appears in the message
- the offending type is named
- the fields actually present are listed

One existing destructuring test pinned the old wording. Behaviour is unchanged — it still throws — so the assertion moves to the new text.

## Not fixed here

`unify.ts` still has `throw new Error('Nested record structures not yet implemented')` in the `has`-constraint validation path. I tried hard to reach it after #124 made nested constraints common — through `map`, wrapping lambdas, `|`, `|>`, `<|`, and a three-deep chain — and could not. It stays unreachable because `unify` only ever sees the object-level (simple) constraints; the composed nested one lives on the function type. Latent, not live. Worth removing when `constraint-resolution` moves onto the store (steps 3–4 of the design note), rather than guessing at it now.

Suite **1145 pass / 10 skip / 0 fail**. Typecheck clean. `validate_examples.js` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)