### PR TITLE
Retire the findResultVariable trap; validate nested structures

### DIFF
--- a/docs-wip/CONSTRAINT_STORE_DESIGN.md
+++ b/docs-wip/CONSTRAINT_STORE_DESIGN.md
@@ -1,6 +1,31 @@
 # Structural constraint store — design note
 
-Status: proposal. Written 2026-07-11, after PRs #121 and #122.
+Status: **landed**, except where noted below. Written 2026-07-11 after PRs #121
+and #122; delivered by #123 (store), #124 (composition), #125 (error messages)
+and #126 (cleanup).
+
+What shipped, against the plan below:
+
+- Steps 1–2 (store, then composition driven from it): done, #123 and #124.
+  `generateDepthFirstConstraints` is deleted.
+- Step 3 (`constraint-resolution` reads the store): done in the form that
+  mattered — unification now collects constraints from the store as well as the
+  objects, and the `findResultVariable` trap described under Hazards is deleted.
+- Step 4 (remove constraint mutation from `unify`; drop `.constraints` from
+  variable objects): **not done, deliberately.** The store is authoritative and
+  enforcement reads both sources, so identity divergence can no longer drop a
+  constraint — the bug this was meant to prevent. Actually removing the object
+  path means rewiring the type printer and `propagateConstraintToTypeVariable`
+  for zero behavioural gain, in an area that goes green and wrong. Worth doing
+  only alongside a reason to touch those two.
+
+One landmine remains, unreached: nested structures cannot arrive at unification
+today (composed constraints live on function types, not on variables), so the
+recursive validator added in #126 is exercised by direct unit tests rather than
+by any expression. If a future change routes a composed constraint through
+`unifyVariable`, that path is ready — but nothing proves it end to end.
+
+The rest of this note is the original proposal, kept for the reasoning.
 
 ## The goal
 

--- a/docs-wip/GENERALIZATION_BUG.md
+++ b/docs-wip/GENERALIZATION_BUG.md
@@ -1,0 +1,77 @@
+# Generalization ignores the substitution — unsound, and not a one-liner
+
+Found 2026-07-11 while chasing the two skipped `where`-inference tests. Not
+fixed. Attempted, reverted, written down instead.
+
+## The bug
+
+`generalize` (`type-operations.ts`) substitutes the type it is about to
+generalize, but reads the environment **raw**:
+
+```ts
+const substitutedType = substitute(type, substitution);
+const typeVars = freeTypeVars(substitutedType);
+const envVars = freeTypeVarsEnv(env);          // ← no substitution
+```
+
+The two sides therefore speak different names. A parameter variable bound during
+body inference (`α216 := α220`) still appears as `α216` in the environment, while
+the value's type now says `α220`. So `α220` looks free-in-type-but-not-in-env and
+gets quantified — even though it *is* the function's parameter, and is still
+monomorphic. Textbook Hindley-Milner says free variables of the environment must
+be computed under the current substitution.
+
+## What it costs
+
+Binding an expression to a name inside a function severs its type from the
+parameters:
+
+```
+fn x y => x + y                        a -> a -> a given a implements Add   correct
+fn x y => (result = x + y; result)     a -> a -> b                          wrong: severed, Add dropped
+fn x y => result where (result = x+y)  a -> a -> b given b implements Add   wrong: b unlinked
+```
+
+This is what the two skipped tests in `trait-function-return-types.test.ts` were
+circling, though they assert the wrong thing about it — see below.
+
+## Why the obvious fix does not work
+
+Passing the substitution into `freeTypeVarsEnv` (resolving each environment
+variable through it, and excluding each scheme's own quantified variables) fixes
+the three cases above and keeps let-polymorphism working
+(`id = fn x => x; {id 1, id "a"}` still infers `{Float, String}`).
+
+It also **breaks 205 tests**, starting with `stdlib.noo` failing to type-check at
+line 160:
+
+```
+TypeError: Occurs check failed: α28 occurs in Option a
+```
+
+The change makes generalization strictly less aggressive across the board. Some
+definition that must stay polymorphic goes monomorphic, gets used at two types,
+and the occurs check fires. Diagnosing *which* environment entries are wrongly
+contributing free variables — and whether the real fault is stale schemes
+lingering in the environment — is the actual work here. It is a day, not an
+afternoon, and it destabilises the whole typer while in flight.
+
+Deliberately not shipped as a half-fix.
+
+## Note on the two skipped tests
+
+`trait-function-return-types.test.ts` skips two `where` tests expecting
+`fn x => result where (y = x + 1; result = y == 42)` to infer a **constrained**
+type carrying `Add` and `Eq`. That expectation is obsolete: numeric literals are
+all `Float` now (Int was removed), so `x + 1` genuinely pins `x` to `Float` and
+`Float -> Bool` is the correct answer. The non-`where` spelling agrees:
+
+```
+fn x => (x + 1) == 42                            Float -> Bool
+fn x => result where (y = x + 1; result = y==42) Float -> Bool
+```
+
+So `where` is not broken in the way those tests claim, and un-skipping them as
+written would be wrong. Rewrite them against the real bug above — a `where`
+binding whose type must stay linked to the enclosing function's parameters —
+or delete them.

--- a/src/typer/__tests__/nested-structural-validation.test.ts
+++ b/src/typer/__tests__/nested-structural-validation.test.ts
@@ -1,0 +1,110 @@
+import { test, expect, describe } from 'bun:test';
+import { validateStructuralConstraint } from '../unify';
+import { createTypeState } from '../type-operations';
+import {
+	floatType,
+	stringType,
+	recordType,
+	typeVariable,
+	type RecordStructure,
+} from '../../ast';
+
+// A nested structure is what a chained accessor composes to — `p has {@address
+// {@city b}}`. Validating one has to descend into @address and check the inner
+// record too. unify used to throw "Nested record structures not yet implemented"
+// here, which was survivable only because nested constraints never reached it.
+//
+// They still do not reach it by any route I could find through the surface
+// language, so these exercise the validator directly. Testing it through an
+// expression would prove nothing: the assertion would pass whether or not the
+// recursion works.
+
+const nested = (
+	outerField: string,
+	innerField: string,
+	innerType = typeVariable('b')
+): RecordStructure => ({
+	fields: {
+		[outerField]: {
+			kind: 'nested',
+			structure: { fields: { [innerField]: innerType } },
+		},
+	},
+});
+
+describe('Nested structural constraint validation', () => {
+	test('accepts a record whose nested field satisfies the inner structure', () => {
+		const actual = recordType({
+			address: recordType({ city: stringType(), street: stringType() }),
+		});
+		const state = validateStructuralConstraint(
+			actual,
+			nested('address', 'city'),
+			createTypeState()
+		);
+		// The inner field's type flows into the constraint's leaf variable.
+		expect(state.substitution.get('b')).toEqual(stringType());
+	});
+
+	test('rejects a record whose nested field lacks the inner field', () => {
+		const actual = recordType({
+			address: recordType({ street: stringType() }),
+		});
+		expect(() =>
+			validateStructuralConstraint(
+				actual,
+				nested('address', 'city'),
+				createTypeState()
+			)
+		).toThrow(/Record has no field @city/);
+	});
+
+	test('rejects a record whose nested field is not a record', () => {
+		const actual = recordType({ address: floatType() });
+		expect(() =>
+			validateStructuralConstraint(
+				actual,
+				nested('address', 'city'),
+				createTypeState()
+			)
+		).toThrow(/Cannot access @city on Float/);
+	});
+
+	test('rejects a record missing the outer field entirely', () => {
+		const actual = recordType({ name: stringType() });
+		expect(() =>
+			validateStructuralConstraint(
+				actual,
+				nested('address', 'city'),
+				createTypeState()
+			)
+		).toThrow(/Record has no field @address/);
+	});
+
+	test('recurses to arbitrary depth', () => {
+		const actual = recordType({
+			a: recordType({ b: recordType({ c: floatType() }) }),
+		});
+		const structure: RecordStructure = {
+			fields: {
+				a: {
+					kind: 'nested',
+					structure: {
+						fields: {
+							b: {
+								kind: 'nested',
+								structure: { fields: { c: typeVariable('leaf') } },
+							},
+						},
+					},
+				},
+			},
+		};
+		const state = validateStructuralConstraint(
+			actual,
+			structure,
+			createTypeState()
+		);
+		expect(state.substitution.get('leaf')).toEqual(floatType());
+	});
+});

--- a/src/typer/constraint-resolution.ts
+++ b/src/typer/constraint-resolution.ts
@@ -239,49 +239,22 @@ export function tryResolveConstraints(
 								}
 							}
 						}
-						// Apply substitution to return type (used only by the special
-						// case below to detect an unsubstituted accessor return var).
-						let resolvedType = substitute(returnType, substitution);
+						// The field variables bound above are the whole result: the
+						// return type is substituted once, from mergedSubstitution, after
+						// every constraint has contributed.
+						//
+						// There used to be a SPECIAL CASE here that, when the return type
+						// was still an unbound variable, bound it to the FIRST field
+						// variable it could find in the constraint's structure. For an
+						// accessor whose constraint names exactly one field that happened
+						// to be right; for anything else it silently picked the wrong
+						// field. That is what made `fn p => getCity (getAddress p)` report
+						// the address record where the city String belonged. Composition
+						// (constraint-composition.ts) plus the lift guard in
+						// buildNormalFunctionType now keep the leaf variable genuinely
+						// linked to the return type, so guessing is neither needed nor
+						// safe.
 
-						// SPECIAL CASE: If the return type is still a variable and we have field type substitutions,
-						// check if the return type should be unified with the field type (common in accessor functions)
-						if (
-							resolvedType.kind === 'variable' &&
-							resolvedType === returnType
-						) {
-							// The return type wasn't substituted, but we have field substitutions
-							// In accessor functions, the return type should match the field type
-							// Handle both simple and nested field constraints
-							function findResultVariable(
-								fields: Record<string, StructureFieldType>
-							): Type | null {
-								for (const [_fieldName, fieldType] of Object.entries(fields)) {
-									if (
-										fieldType.kind === 'variable' &&
-										substitution.has(fieldType.name)
-									) {
-										// Found a direct variable that was substituted
-										return substitution.get(fieldType.name)!;
-									} else if (fieldType.kind === 'nested') {
-										// Recursively search nested structure
-										const nestedResult = findResultVariable(
-											fieldType.structure.fields
-										);
-										if (nestedResult) return nestedResult;
-									}
-								}
-								return null;
-							}
-
-							const resultType = findResultVariable(requiredStructure.fields);
-							if (resultType) {
-								substitution.set(resolvedType.name, resultType);
-								resolvedType = resultType;
-							}
-						}
-						// Reference resolvedType so it is not flagged as unused; the
-						// authoritative result comes from mergedSubstitution below.
-						void resolvedType;
 						// Accumulate this constraint's substitution and continue.
 						for (const [k, v] of substitution) mergedSubstitution.set(k, v);
 						resolvedAny = true;

--- a/src/typer/unify.ts
+++ b/src/typer/unify.ts
@@ -1,4 +1,4 @@
-import { Type, Constraint } from '../ast';
+import { Type, Constraint, type RecordStructure } from '../ast';
 import { substitute } from './substitute';
 import { TypeState } from './types';
 import { isTypeKind, typesEqual, constraintsEqual } from './helpers';
@@ -439,6 +439,90 @@ function unifyUnit(
 	return state;
 }
 
+/**
+ * Check a concrete type against a structural constraint, recursing into nested
+ * structures.
+ *
+ * A nested structure is what a chained accessor composes to — `p has {@address
+ * {@city b}}` — so validation has to descend into `@address` and check the inner
+ * record too. This previously threw "Nested record structures not yet
+ * implemented", which was survivable only because nested constraints never
+ * reached unification.
+ */
+export function validateStructuralConstraint(
+	actual: Type,
+	structure: RecordStructure,
+	state: TypeState,
+	location?: { line: number; column: number }
+): TypeState {
+	const required = Object.keys(structure.fields).map(f => `@${f}`);
+
+	if (!isTypeKind(actual, 'record')) {
+		throw new Error(
+			formatTypeError(
+				createTypeError(
+					`Cannot access ${required.join(', ')} on ${typeToString(
+						actual,
+						state.substitution
+					)}`,
+					{
+						actualType: actual,
+						suggestion: `Field access requires a record with ${required.join(
+							', '
+						)}.`,
+					},
+					location || { line: 1, column: 1 }
+				)
+			)
+		);
+	}
+
+	let newState = state;
+
+	for (const [fieldName, expectedFieldType] of Object.entries(
+		structure.fields
+	)) {
+		if (!(fieldName in actual.fields)) {
+			const present = Object.keys(actual.fields).map(f => `@${f}`);
+			throw new Error(
+				formatTypeError(
+					createTypeError(
+						`Record has no field @${fieldName}`,
+						{
+							actualType: actual,
+							suggestion:
+								present.length > 0
+									? `This record has ${present.join(
+											', '
+										)}. Check the field name.`
+									: `This record has no fields.`,
+						},
+						location || { line: 1, column: 1 }
+					)
+				)
+			);
+		}
+
+		const actualFieldType = substitute(
+			actual.fields[fieldName],
+			newState.substitution
+		);
+
+		if (expectedFieldType.kind === 'nested') {
+			newState = validateStructuralConstraint(
+				actualFieldType,
+				expectedFieldType.structure,
+				newState,
+				location
+			);
+		} else {
+			newState = unify(actualFieldType, expectedFieldType, newState, location);
+		}
+	}
+
+	return newState;
+}
+
 // --- Unification helpers ---
 function unifyVariable(
 	s1: Type,
@@ -449,17 +533,29 @@ function unifyVariable(
 	if (!isTypeKind(s1, 'variable')) {
 		throw new Error('unifyVariable called with non-variable s1');
 	}
-	// Optimized constraint collection - avoid array spreading
+	// Collect the constraints s1 carries, walking its substitution chain.
+	//
+	// Both sources are read. The store is authoritative — it is keyed by NAME and
+	// so survives the structure-copying that instantiation performs. The variable
+	// OBJECTS are still consulted because parts of the typer (typeAccessor,
+	// propagateConstraintToTypeVariable, the type printer) continue to hang
+	// constraints there, and a constraint recorded only on an object would
+	// otherwise stop being enforced.
 	const constraintsToCheck: Constraint[] = [];
+	const pushUnique = (c: Constraint) => {
+		if (!constraintsToCheck.some(existing => constraintsEqual(c, existing))) {
+			constraintsToCheck.push(c);
+		}
+	};
 	const seenVars = new Set<string>();
 	let currentVar: Type = s1;
 	while (isTypeKind(currentVar, 'variable')) {
 		if (seenVars.has(currentVar.name)) break;
 		seenVars.add(currentVar.name);
-		if (currentVar.constraints) {
-			// Use forEach instead of spread for better performance
-			currentVar.constraints.forEach(c => constraintsToCheck.push(c));
-		}
+		currentVar.constraints?.forEach(pushUnique);
+		getConstraints(state.constraints, currentVar.name, state.substitution).forEach(
+			pushUnique
+		);
 		const next = state.substitution.get(currentVar.name);
 		if (!next) break;
 		currentVar = next;
@@ -529,77 +625,12 @@ function unifyVariable(
 					location
 				);
 			} else if (constraint.kind === 'has') {
-				if (isTypeKind(s2, 'record')) {
-					// Validate that s2 has all required fields with correct types
-					for (const [fieldName, expectedFieldType] of Object.entries(
-						constraint.structure.fields
-					)) {
-						if (!(fieldName in s2.fields)) {
-							const present = Object.keys(s2.fields).map(f => `@${f}`);
-							throw new Error(
-								formatTypeError(
-									createTypeError(
-										`Record has no field @${fieldName}`,
-										{
-											actualType: s2,
-											suggestion:
-												present.length > 0
-													? `This record has ${present.join(
-															', '
-														)}. Check the field name.`
-													: `This record has no fields.`,
-										},
-										location || { line: 1, column: 1 }
-									)
-								)
-							);
-						}
-
-						// Handle StructureFieldType (can be Type or nested structure)
-						if (
-							typeof expectedFieldType === 'object' &&
-							expectedFieldType !== null &&
-							'kind' in expectedFieldType
-						) {
-							if (expectedFieldType.kind === 'nested') {
-								// TODO: Handle nested record structures
-								throw new Error('Nested record structures not yet implemented');
-							} else {
-								// It's a regular Type
-								newState = unify(
-									s2.fields[fieldName],
-									expectedFieldType as Type,
-									newState,
-									location
-								);
-							}
-						} else {
-							throw new Error(
-								`Invalid field type in constraint: ${typeof expectedFieldType}`
-							);
-						}
-					}
-				} else {
-					// s2 is not a record type, but the constraint requires record structure
-					const fieldNames = Object.keys(constraint.structure.fields)
-						.map(f => `@${f}`)
-						.join(', ');
-					throw new Error(
-						formatTypeError(
-							createTypeError(
-								`Cannot access ${fieldNames} on ${typeToString(
-									s2,
-									state.substitution
-								)}`,
-								{
-									actualType: s2,
-									suggestion: `Field access requires a record with ${fieldNames}.`,
-								},
-								location || { line: 1, column: 1 }
-							)
-						)
-					);
-				}
+				newState = validateStructuralConstraint(
+					s2,
+					constraint.structure,
+					newState,
+					location
+				);
 			} else if (constraint.kind === 'is') {
 				// NOTE: Legacy constraint checking removed - handled by new trait system
 				// TODO: Implement proper constraint checking in Phase 2


### PR DESCRIPTION
Cleanup pass over the constraint machinery — steps 3–4 of [`docs-wip/CONSTRAINT_STORE_DESIGN.md`](docs-wip/CONSTRAINT_STORE_DESIGN.md), following #121–#125.

**No inferred type changes.** Verified by reading types, not by watching the suite go green — this area is exactly where that distinction bites.

## 1. Deletes the `findResultVariable` trap

`tryResolveConstraints` had a SPECIAL CASE: when the return type was still an unbound variable, bind it to the **first** field variable found in the constraint's structure.

For a single-field accessor constraint that guess is right. For anything else it silently picks the wrong field — which is precisely what made an earlier revision of #122 report the **address record** where the city `String` belonged.

Composition (#124) plus the lift guard now keep the leaf variable genuinely linked to the return type, so the guess is neither needed nor safe. Deleting it changes **no** inferred type. It was dead weight, and a loaded gun.

## 2. Nested structures are actually validated

```
- throw new Error('Nested record structures not yet implemented');
+ recursive structural validation
```

A nested structure is exactly what a chained accessor composes to (`p has {@address {@city b}}`), so validation must descend into `@address` and check the inner record.

The throw was survivable only because nested constraints never reach unification — **still true**, which is why the validator is exported and tested directly. Testing it through an expression would assert nothing: it would pass whether or not the recursion works. Five tests cover the happy path, missing inner field, non-record inner field, missing outer field, and arbitrary depth.

## 3. Unification reads the constraint store

Constraints are now collected from the name-keyed store **as well as** the variable objects. The store is authoritative: keyed by name, it survives the structure-copying that instantiation performs, so a constraint can no longer be dropped through object-identity divergence — the failure mode this whole series has been chasing.

The objects are still read, because `typeAccessor`, `propagateConstraintToTypeVariable` and the type printer keep writing there. A constraint recorded only on an object must not stop being enforced.

## What I deliberately did not do

Removing the object-level constraints outright means rewiring the type printer and `propagateConstraintToTypeVariable`. That is a sizeable refactor for **zero** behavioural gain now that the store is authoritative and enforcement reads both. Not worth the risk in an area that goes green and wrong. Left as a note in the design doc.

## Verification

Positive — unchanged:

```
map @name [{@name "bob"}]                     List String
map (fn p => @age p) [{@age 3}]               List Float
fn p => getCity (getAddr p)                   a -> b given a has {@address {@city b}}
  …applied to a record                        String
fn p => (@age p) + 1                          a -> Float given a has {@age b}   (partial: not lifted)
@name? {@x 1}                                 Option a
```

Negative — still rejected, with the right message:

```
getAddr 1                          Cannot access @address on Float
getCity {@name "A"}                Record has no field @city
f {@address {@street "S"}}         Record has no field @city
f {@address 1}                     Cannot access @city on Float
```

Suite **1160 pass / 10 skip / 0 fail**. Typecheck clean. `validate_examples.js` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)