### PR TITLE
Fix unsound generalization severing let/where-bound results from params

### DIFF
--- a/docs-wip/GENERALIZATION_BUG.md
+++ b/docs-wip/GENERALIZATION_BUG.md
@@ -1,7 +1,10 @@
 # Generalization ignores the substitution — unsound, and not a one-liner
 
-Found 2026-07-11 while chasing the two skipped `where`-inference tests. Not
-fixed. Attempted, reverted, written down instead.
+Found 2026-07-11 while chasing the two skipped `where`-inference tests.
+**Fixed 2026-07-11** (same session, continued). See "Resolution" at the
+bottom — the 205-test regression predicted below turned out to be a single
+upstream cascade (stdlib failing to *load* at all breaks every test that
+touches it), not 205 independent breakages.
 
 ## The bug
 
@@ -75,3 +78,58 @@ So `where` is not broken in the way those tests claim, and un-skipping them as
 written would be wrong. Rewrite them against the real bug above — a `where`
 binding whose type must stay linked to the enclosing function's parameters —
 or delete them.
+
+## Resolution (2026-07-11)
+
+Shipped the fix described above: `freeTypeVarsEnv` now takes the substitution,
+resolves each scheme's type through it, and excludes the scheme's own
+`quantifiedVars` (previously a stored polymorphic scheme's bound var names
+leaked into "env vars" too, though harmlessly in practice since fresh-var
+names are monotonic and never collide).
+
+**The predicted 205-test regression was a mirage.** `stdlib.noo` failing to
+*load* fails every test that touches stdlib (nearly all of them) — one root
+cause, not 205. The actual failure was real, just singular: `Monad Option`'s
+and `Monad Result`'s `bind` both had an "auto-wrap non-Option/Result values"
+arm —
+
+```
+result = f x;
+match result (
+  Some y => result;
+  None => result;
+  _ => Some result   # auto-wrap
+)
+```
+
+— which requires unifying `result`'s type (`b`, from `f x`) with `Option b`
+(the wrapped fallback). That's `b ~ Option b`, an infinite type. The occurs
+check firing here is **correct** — this was never sound. It only typechecked
+before because the old buggy `generalize` over-generalized `b` and let each
+match arm re-instantiate it independently, hiding the paradox. Confirmed by
+reproducing the identical failure on `Monad Result` after fixing `Monad
+Option`, proving one bug pattern, not many.
+
+Fix, two parts:
+
+1. `type-operations.ts` — `freeTypeVarsEnv`/`generalize` as described above.
+2. `stdlib.noo` — removed the auto-wrap arm from both `bind` impls; a lawful
+   `bind` requires `f` to always return the monad's own type. `Some x => f x`,
+   full stop.
+
+Removing (2) broke `|?` (safe thrush), which had been leaning on `bind`'s
+auto-wrap to let a plain (non-Option-returning) right-hand function chain —
+`Some 5 |? add_ten` expects `Some 15` even though `add_ten : Float -> Float`.
+That coercion can't live in `bind` (same occurs-check reason), so it moved to
+`|?`'s own evaluator branch (`evaluator.ts`, the `'|?'` case), which now
+applies the right-hand function directly and wraps the result only if it
+isn't already the monad's own constructor — mirroring logic the *typer*
+already had in `handleSafeThrush`'s fallback path, which was computing the
+right type all along while the evaluator silently returned the wrong
+*value* (type said `Option Float`, runtime value was a bare `Float` — a
+live instance of the "green and wrong" hazard).
+
+Net: full suite green (1153 pass / 8 skip / 0 fail — 2 stale skips deleted),
+typecheck clean, docs 6/6 + README 57/57. Regression tests added in
+`trait-function-return-types.test.ts` for both the `where`- and
+semicolon-let-bound cases.

--- a/src/evaluator/evaluator.ts
+++ b/src/evaluator/evaluator.ts
@@ -1947,38 +1947,54 @@ export class Evaluator {
 				);
 			}
 		} else if (expr.operator === '|?') {
-			// The |? operator should be desugared to a bind call by the type checker
-			// However, if constraint resolution failed, we might still see |? here
-			// Fall back to calling the trait bind function directly
+			// |? auto-wraps a plain (non-Option/Result-returning) right-hand
+			// function's result, unlike a lawful Monad.bind (which cannot express
+			// that: unifying the result type with its own wrapped form is an
+			// infinite type, caught by the occurs check). So this can't delegate
+			// to bind — it applies the payload directly and wraps on the way out.
 			const left = this.evaluateExpression(expr.left);
 			const right = this.evaluateExpression(expr.right);
 
-			// Check that right operand is a function
 			if (!isAnyFunction(right)) {
 				throw new Error(
 					`Cannot apply non-function in safe thrush: ${valueToString(right)}`
 				);
 			}
+			if (!isConstructor(left)) {
+				throw new Error(
+					`Safe thrush operator (|?) requires an Option or Result, got ${valueToString(left)}`
+				);
+			}
 
-			// Try to resolve bind as a trait function
-			if (this.isTraitFunction('bind')) {
-				try {
-					// Use trait function resolution for bind
-					const result = this.resolveTraitFunctionWithArgs(
-						'bind',
-						[left, right],
-						this.traitRegistry
-					);
-					if (result) {
-						return result;
-					}
-				} catch (_e) {
-					// Fall through to legacy lookup
+			const applyRight = (arg: Value): Value =>
+				isFunction(right) || isNativeFunction(right)
+					? right.fn(arg)
+					: (() => {
+							throw new Error(
+								`Cannot apply non-function in safe thrush: ${valueToString(right)}`
+							);
+						})();
+
+			if (left.name === 'None' || left.name === 'Err') {
+				return left;
+			}
+			if (left.name === 'Some') {
+				const result = applyRight(left.args[0]);
+				if (isConstructor(result) && (result.name === 'Some' || result.name === 'None')) {
+					return result;
 				}
+				return { tag: 'constructor', name: 'Some', args: [result] };
+			}
+			if (left.name === 'Ok') {
+				const result = applyRight(left.args[0]);
+				if (isConstructor(result) && (result.name === 'Ok' || result.name === 'Err')) {
+					return result;
+				}
+				return { tag: 'constructor', name: 'Ok', args: [result] };
 			}
 
 			throw new Error(
-				'Safe thrush operator (|?) failed: no bind function available'
+				`Safe thrush operator (|?) requires an Option or Result, got ${left.name}`
 			);
 		} else if (expr.operator === '$') {
 			// Handle dollar operator (low precedence function application)

--- a/src/typer/__tests__/trait-function-return-types.test.ts
+++ b/src/typer/__tests__/trait-function-return-types.test.ts
@@ -5,7 +5,6 @@ import {
 	assertPrimitiveType,
 	assertVariantType,
 	parseAndType,
-	assertConstrainedType,
 	assertImplementsConstraint,
 } from '../../../test/utils';
 
@@ -100,8 +99,10 @@ test('should infer constraints in if expressions', () => {
 	);
 });
 
-// TODO fix where not working in function bodies
-test.skip('should infer constraints in where expressions', () => {
+// `x + 1` pins x to Float (numeric literals are all Float now, Int was
+// removed), so `Float -> Bool` is correct here, not a constrained type -
+// see docs-wip/GENERALIZATION_BUG.md.
+test('where-bound result concretely typed when literals pin the type', () => {
 	const code = `
 			fn x => result where (
 				y = x + 1;
@@ -110,19 +111,35 @@ test.skip('should infer constraints in where expressions', () => {
 		`;
 	const typeResult = parseAndType(code);
 
-	expect(typeResult.type.kind).toBe('constrained');
-	assertConstrainedType(typeResult.type);
+	assertFunctionType(typeResult.type);
+	assertPrimitiveType(typeResult.type.params[0]);
+	expect(typeResult.type.params[0].name).toBe('Float');
+	assertVariantType(typeResult.type.return);
+	expect(typeResult.type.return.name).toBe('Bool');
+});
 
-	const constraintEntries = Array.from(typeResult.type.constraints.entries());
-	expect(constraintEntries.length).toBeGreaterThan(0);
+// Regression for the generalize/freeTypeVarsEnv bug (GENERALIZATION_BUG.md):
+// a where-bound (or semicolon-let-bound) result must stay linked to the
+// enclosing function's parameters, not get quantified as an unrelated var
+// with its constraint dropped.
+test('where-bound result stays linked to params and keeps its constraint', () => {
+	const code = 'fn x y => result where (result = x + y)';
+	const typeResult = parseAndType(code);
 
-	const constraints = constraintEntries[0][1];
-	const traitNames = constraints.map(c => {
-		assertImplementsConstraint(c);
-		return c.interfaceName;
-	});
-	expect(traitNames).toContain('Add');
-	expect(traitNames).toContain('Eq');
+	assertFunctionType(typeResult.type);
+	expect(typeResult.type.constraints?.length).toBeGreaterThan(0);
+	assertImplementsConstraint(typeResult.type.constraints![0]);
+	expect(typeResult.type.constraints![0].interfaceName).toBe('Add');
+});
+
+test('semicolon-let-bound result stays linked to params and keeps its constraint', () => {
+	const code = 'fn x y => (result = x + y; result)';
+	const typeResult = parseAndType(code);
+
+	assertFunctionType(typeResult.type);
+	expect(typeResult.type.constraints?.length).toBeGreaterThan(0);
+	assertImplementsConstraint(typeResult.type.constraints![0]);
+	expect(typeResult.type.constraints![0].interfaceName).toBe('Add');
 });
 
 test('should work with concrete types that implement traits', () => {
@@ -141,33 +158,4 @@ test('should work with concrete types that implement traits', () => {
 	assertPrimitiveType(appliedResult.type);
 	expect(appliedResult.type.name).toBe('Float');
 });
-
-// TODO fix where not working in function bodies
-test.skip('should handle complex nested expressions', () => {
-	const code = `
-		fn x => where (
-			temp = x + 10;
-			check = temp == 50;
-			result = if check then x * 2 else x - 5
-		) result
-	`;
-	const typeResult = parseAndType(code);
-
-	expect(typeResult.type.kind).toBe('constrained');
-	assertConstrainedType(typeResult.type);
-
-	const constraintEntries = Array.from(typeResult.type.constraints.entries());
-	expect(constraintEntries.length).toBeGreaterThan(0);
-
-	const constraints = constraintEntries[0][1];
-	const traitNames = constraints.map(c => {
-		assertImplementsConstraint(c);
-		return c.interfaceName;
-	});
-	expect(traitNames).toContain('Add');
-	expect(traitNames).toContain('Eq');
-	expect(traitNames).toContain('Mul');
-	expect(traitNames).toContain('Sub');
-});
-
 

--- a/src/typer/type-inference.ts
+++ b/src/typer/type-inference.ts
@@ -733,6 +733,16 @@ function usesOperator(expr: Expression, targetOperator: string): boolean {
 				usesOperator(expr.expression, targetOperator) ||
 				expr.cases.some(case_ => usesOperator(case_.expression, targetOperator))
 			);
+		case 'definition':
+		case 'tuple-destructuring':
+		case 'record-destructuring':
+		case 'mutable-definition':
+			// A `;`-sequence desugars to nested binary(';') nodes whose left side
+			// is one of these binding kinds (see parseSequence) — without this,
+			// `(result = x + y; result)` never saw the `+` and lost its Add
+			// constraint even after the generalization fix linked `result`'s
+			// type back to the params.
+			return usesOperator(expr.value, targetOperator);
 		default:
 			return false;
 	}

--- a/src/typer/type-operations.ts
+++ b/src/typer/type-operations.ts
@@ -88,10 +88,16 @@ export const freeTypeVars = (
 };
 
 // Collect all free type variables in the environment
-export const freeTypeVarsEnv = (env: TypeEnvironment): Set<string> => {
+export const freeTypeVarsEnv = (
+	env: TypeEnvironment,
+	substitution?: Map<string, Type>
+): Set<string> => {
 	const acc = new Set<string>();
 	for (const scheme of env.values()) {
-		freeTypeVars(scheme.type, acc);
+		const type = substitution ? substitute(scheme.type, substitution) : scheme.type;
+		for (const varName of freeTypeVars(type)) {
+			if (!scheme.quantifiedVars.includes(varName)) acc.add(varName);
+		}
 	}
 	return acc;
 };
@@ -105,7 +111,11 @@ export const generalize = (
 	// Apply current substitution to the type before generalizing
 	const substitutedType = substitute(type, substitution);
 	const typeVars = freeTypeVars(substitutedType);
-	const envVars = freeTypeVarsEnv(env);
+	// Environment variables must be resolved through the same substitution:
+	// a param bound during body inference (α216 := α220) otherwise still reads
+	// as α216 in the env while the value's type says α220, so α220 looks free
+	// and gets wrongly quantified. See docs-wip/GENERALIZATION_BUG.md.
+	const envVars = freeTypeVarsEnv(env, substitution);
 	const quantifiedVars: string[] = [];
 
 	for (const varName of typeVars) {

--- a/stdlib.noo
+++ b/stdlib.noo
@@ -152,14 +152,7 @@ option_get_or = fn default opt => match opt (
 # Map over Option (using Monad constraint)
 implement Monad Option (
   bind = fn opt f => match opt (
-    Some x => (
-      result = f x;
-      match result (
-        Some y => result;
-        None => result;
-        _ => Some result  # Auto-wrap non-Option values
-      )
-    );
+    Some x => f x;
     None => None
   );
   pure = fn x => Some x
@@ -218,14 +211,7 @@ result_get_or = fn default res => match res (
 # Map over Result value (using Monad constraint) 
 implement Monad Result (
   bind = fn res f => match res (
-    Ok x => (
-      result = f x;
-      match result (
-        Ok y => result;
-        Err e => result;
-        _ => Ok result  # Auto-wrap non-Result values
-      )
-    );
+    Ok x => f x;
     Err e => Err e
   );
   pure = fn x => Ok x


### PR DESCRIPTION
## Summary
- `generalize()` read the environment raw instead of through the current substitution, so a function parameter bound during body inference could look free and get wrongly quantified — `fn x y => (result = x + y; result)` inferred `a -> a -> b` (severed, Add dropped) instead of `a -> a -> a given a implements Add`.
- Fixing that surfaced an unsound `bind` auto-wrap arm in `Monad Option`/`Monad Result` (required `b ~ Option b`, an infinite type — the occurs check catching it was correct, not a false positive) and a related lie between type and value in `|?` (safe thrush), which depended on that auto-wrap.
- Also fixed `usesOperator`'s implicit-`Add`-constraint detector, which had no case for `definition`/destructuring nodes, so a `;`-sequence's `+` never registered.
- Deleted two skipped `where` tests asserting an obsolete expectation, replaced with three real regression tests.

Full narrative in `docs-wip/GENERALIZATION_BUG.md`'s Resolution section.

## Test plan
- [x] `AGENT=1 bun test` — 1153 pass / 8 skip / 0 fail
- [x] `bun run typecheck` — clean
- [x] `node validate_examples.js` — docs 6/6, README 57/57

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TASnoHntaoTfJZpshTGnB