### PR TITLE
Add association-list helpers to stdlib.noo

### DIFF
--- a/src/typer/__tests__/assoc-list.test.ts
+++ b/src/typer/__tests__/assoc-list.test.ts
@@ -1,0 +1,63 @@
+import { test, expect, describe } from 'bun:test';
+import { expectSuccess, runCode } from '../../../test/utils';
+
+describe('Association-list helpers (stdlib)', () => {
+	test('assoc_get finds the value for a matching key', () => {
+		const result = runCode('assoc_get "b" [{"a", 1}, {"b", 2}]');
+		expect(result.finalValue).toEqual({
+			tag: 'constructor',
+			name: 'Some',
+			args: [{ tag: 'number', value: 2 }],
+		});
+	});
+
+	test('assoc_get returns None for a missing key', () => {
+		const result = runCode('assoc_get "z" [{"a", 1}, {"b", 2}]');
+		expect(result.finalValue).toEqual({
+			tag: 'constructor',
+			name: 'None',
+			args: [],
+		});
+	});
+
+	test('assoc_set inserts a new key', () => {
+		expectSuccess('assoc_set "b" 2 [{"a", 1}]', [
+			['a', 1],
+			['b', 2],
+		]);
+	});
+
+	test('assoc_set overwrites an existing key in place', () => {
+		expectSuccess('assoc_set "a" 9 [{"a", 1}, {"b", 2}]', [
+			['a', 9],
+			['b', 2],
+		]);
+	});
+
+	test('assoc_update applies a function to the existing value, or seeds a default', () => {
+		expectSuccess(
+			'assoc_update "a" (fn v => v + 1) 1 [{"a", 4}]',
+			[['a', 5]]
+		);
+		expectSuccess(
+			'assoc_update "z" (fn v => v + 1) 1 [{"a", 4}]',
+			[
+				['a', 4],
+				['z', 1],
+			]
+		);
+	});
+
+	test('word_counts tallies word frequency via assoc_update', () => {
+		const code = `
+			tally = fn list => reduce (fn acc w => assoc_update w (fn c => c + 1) 1 acc) [] list;
+			tally ["a", "b", "a", "a", "b", "c"]
+		`;
+		const result = runCode(code);
+		expect(result.finalValue).toEqual([
+			['a', 3],
+			['b', 2],
+			['c', 1],
+		]);
+	});
+});

--- a/stdlib.noo
+++ b/stdlib.noo
@@ -293,6 +293,33 @@ sort = fn list => match (head list) (
   Some h => insert_sorted h (sort (tail list))
 );
 
+# Association-list helpers: List {key, value} as a small linear map.
+# Deliberately not a dedicated Map/Dict type - this covers the common
+# case (tally, group-by) without adding a new collection primitive;
+# revisit only if a real program needs O(1) lookup at real scale.
+assoc_get = fn key list => match (head list) (
+  None => None;
+  Some pair => (
+    {a, b} = pair;
+    if a == key then Some b else assoc_get key (tail list)
+  )
+);
+
+assoc_set = fn key value list => match (head list) (
+  None => [{key, value}];
+  Some pair => (
+    {a, b} = pair;
+    if a == key
+      then cons {key, value} (tail list)
+      else cons pair (assoc_set key value (tail list))
+  )
+);
+
+assoc_update = fn key f default list => match (assoc_get key list) (
+  Some v => assoc_set key (f v) list;
+  None => assoc_set key default list
+);
+
 implement Functor List (
   map = fn f list => list_map f list
 );


### PR DESCRIPTION
## Summary
- Adds `assoc_get`, `assoc_set`, `assoc_update` — pure-Noolang helpers over `List {key, value}`, no new native code or collection type.
- Answers the open question from #129: does Noolang need a dedicated Map/Dict type for general programming? Tested by extending the word-count toy program from dedup to real frequency tallying — association list covers it fully at this scale.

## Test plan
- [x] `AGENT=1 bun test` — 1175 pass / 8 skip / 0 fail
- [x] `bun run typecheck` — clean
- [x] `node validate_examples.js` — all docs + README pass
- [x] New test file `src/typer/__tests__/assoc-list.test.ts`
- [x] Manual end-to-end: word-frequency tally over a real file via `reduce`/`assoc_update` — correct counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TASnoHntaoTfJZpshTGnB