### PR TITLE
Add sort_by to stdlib.noo for comparator-based ordering

### DIFF
--- a/src/typer/__tests__/sort-by.test.ts
+++ b/src/typer/__tests__/sort-by.test.ts
@@ -1,0 +1,36 @@
+import { test, expect, describe } from 'bun:test';
+import { expectSuccess } from '../../../test/utils';
+
+describe('sort_by (stdlib)', () => {
+	test('sorts numbers ascending with an explicit less-than predicate', () => {
+		expectSuccess('sort_by (fn a b => a < b) [3, 1, 4, 1, 5]', [
+			1, 1, 3, 4, 5,
+		]);
+	});
+
+	test('sorts descending when the predicate is reversed', () => {
+		expectSuccess('sort_by (fn a b => a > b) [3, 1, 4, 1, 5]', [
+			5, 4, 3, 1, 1,
+		]);
+	});
+
+	test('sorts tuples by a derived key', () => {
+		const code = `
+			pairs = [{"c", 1}, {"a", 3}, {"b", 2}];
+			sort_by (fn x y => (
+				{ka, va} = x;
+				{kb, vb} = y;
+				va < vb
+			)) pairs
+		`;
+		expectSuccess(code, [
+			['c', 1],
+			['b', 2],
+			['a', 3],
+		]);
+	});
+
+	test('sort_by on an empty list returns an empty list', () => {
+		expectSuccess('sort_by (fn a b => a < b) ([] : List Float)', []);
+	});
+});

--- a/stdlib.noo
+++ b/stdlib.noo
@@ -293,6 +293,21 @@ sort = fn list => match (head list) (
   Some h => insert_sorted h (sort (tail list))
 );
 
+# Sort with an explicit less-than predicate, for keys with no Ord instance
+# (tuples, records) or a non-default ordering (descending, derived key).
+insert_sorted_by = fn less_than x list => match (head list) (
+  None => [x];
+  Some h =>
+    if less_than x h
+      then cons x list
+      else cons h (insert_sorted_by less_than x (tail list))
+);
+
+sort_by = fn less_than list => match (head list) (
+  None => [];
+  Some h => insert_sorted_by less_than h (sort_by less_than (tail list))
+);
+
 # Association-list helpers: List {key, value} as a small linear map.
 # Deliberately not a dedicated Map/Dict type - this covers the common
 # case (tally, group-by) without adding a new collection primitive;


### PR DESCRIPTION
## Summary
- `sort` only orders via `Ord` (Float/String). Sorting tuples/records by a derived key — e.g. word-count results by frequency — had no path.
- Adds `sort_by : (a -> a -> Bool) -> List a -> List a`, taking an explicit less-than predicate. Same insertion-sort shape as `sort`/`insert_sorted`, generalized.

## Test plan
- [x] `AGENT=1 bun test` — 1179 pass / 8 skip / 0 fail
- [x] `bun run typecheck` — clean
- [x] `node validate_examples.js` — all docs + README pass
- [x] New test file `src/typer/__tests__/sort-by.test.ts` — ascending, descending, tuple-by-derived-key, empty list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TASnoHntaoTfJZpshTGnB