### PR TITLE
Add operator sectioning: (op) desugars to fn a b => a op b

### DIFF
--- a/src/parser/__tests__/operator-sectioning.test.ts
+++ b/src/parser/__tests__/operator-sectioning.test.ts
@@ -1,0 +1,42 @@
+import { Lexer } from '../../lexer/lexer';
+import { parse } from '../parser';
+import { test, expect, describe } from 'bun:test';
+import { assertFunctionExpression, assertBinaryExpression } from '../../../test/utils';
+import { expectSuccess } from '../../../test/utils';
+
+describe('Operator sectioning: (op) desugars to fn a b => a op b', () => {
+	test('(<) parses to a two-param function applying "<"', () => {
+		const lexer = new Lexer('(<)');
+		const tokens = lexer.tokenize();
+		const program = parse(tokens);
+
+		expect(program.statements.length).toBe(1);
+		const expr = program.statements[0];
+		assertFunctionExpression(expr);
+		expect(expr.params).toHaveLength(2);
+		assertBinaryExpression(expr.body);
+		expect(expr.body.operator).toBe('<');
+	});
+
+	test('(+) evaluates and applies like the infix operator', () => {
+		expectSuccess('(+) 1 2', 3);
+	});
+
+	test('(<) used as a first-class comparator with sort_by', () => {
+		expectSuccess('sort_by (<) [3, 1, 4, 1, 5]', [1, 1, 3, 4, 5]);
+	});
+
+	test('parenthesized negative literal still parses as a literal, not a section', () => {
+		expectSuccess('(-5)', -5);
+	});
+
+	test('a normal parenthesized expression is unaffected', () => {
+		expectSuccess('(1 + 2)', 3);
+	});
+
+	test('(=) is not sectionable - "=" is assignment punctuation, not a binary operator', () => {
+		const lexer = new Lexer('(=)');
+		const tokens = lexer.tokenize();
+		expect(() => parse(tokens)).toThrow();
+	});
+});

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -33,6 +33,7 @@ import {
 	type ImplementationFunction,
 	type MutationExpression,
 	type IfExpression,
+	type BinaryExpression,
 } from '../ast';
 import {
 	parseTypeDefinition,
@@ -235,15 +236,66 @@ const parseRecord = C.map(
 	}
 );
 
-// --- Parenthesized Expressions ---
-const parseParenExpr: C.Parser<Expression> = C.map(
-	C.seq(
+// --- Operator Sectioning: (op) desugars to fn a b => a op b ---
+// Gives parenthesized syntax to pass an operator as a first-class function,
+// e.g. `sort_by (<) list` instead of `sort_by (fn a b => a < b) list`.
+// Desugars rather than referencing the operator's own (uncurried, 2-param)
+// environment binding, so it goes through the same binary-operator typing
+// path as ordinary infix use instead of needing that binding re-typed.
+//
+// The lexer's OPERATOR token also covers '=', '=>', '->' (assignment/arrow
+// punctuation, not binary operators), so sectioning is restricted to the
+// actual BinaryExpression operator set rather than accepting any OPERATOR.
+const sectionableOperators = new Set<BinaryExpression['operator']>([
+	'+', '-', '*', '/', '%', '==', '!=', '<', '>', '<=', '>=',
+	'|', '|?', '|>', '<|', '$',
+]);
+
+const parseOperatorSection: C.Parser<Expression> = tokens => {
+	const seqResult = C.seq(
 		C.punctuation('('),
-		C.lazy(() => parseSequence), // Use parseSequence to allow full semicolon-separated sequences
+		C.token('OPERATOR'),
 		C.punctuation(')')
-	),
-	([_open, expr, _close]) => expr
-);
+	)(tokens);
+	if (!seqResult.success) return seqResult;
+
+	const [_open, op] = seqResult.value;
+	if (!sectionableOperators.has(op.value as BinaryExpression['operator'])) {
+		return {
+			success: false,
+			error: `'${op.value}' cannot be used as a sectioned operator`,
+			position: op.location.start.line,
+		};
+	}
+
+	const fn: FunctionExpression = {
+		kind: 'function',
+		params: ['__section_a', '__section_b'],
+		body: {
+			kind: 'binary',
+			operator: op.value as BinaryExpression['operator'],
+			left: { kind: 'variable', name: '__section_a', location: op.location },
+			right: { kind: 'variable', name: '__section_b', location: op.location },
+			location: op.location,
+		},
+		location: op.location,
+	};
+	return { success: true, value: fn, remaining: seqResult.remaining };
+};
+
+// --- Parenthesized Expressions ---
+const parseParenExpr: C.Parser<Expression> = tokens => {
+	const sectionResult = parseOperatorSection(tokens);
+	if (sectionResult.success) return sectionResult;
+	return C.map(
+		C.seq(
+			C.punctuation('('),
+			C.lazy(() => parseSequence), // Use parseSequence to allow full semicolon-separated sequences
+			C.punctuation(')')
+		),
+		([_open, expr, _close]) => expr
+	)(tokens);
+};
 
 // --- Lambda Expression ---
 const parseLambdaExpression: C.Parser<Expression> = tokens => {

--- a/src/typer/__tests__/sort-by.test.ts
+++ b/src/typer/__tests__/sort-by.test.ts
@@ -3,15 +3,11 @@ import { expectSuccess } from '../../../test/utils';
 
 describe('sort_by (stdlib)', () => {
 	test('sorts numbers ascending with an explicit less-than predicate', () => {
-		expectSuccess('sort_by (fn a b => a < b) [3, 1, 4, 1, 5]', [
-			1, 1, 3, 4, 5,
-		]);
+		expectSuccess('sort_by (<) [3, 1, 4, 1, 5]', [1, 1, 3, 4, 5]);
 	});
 
 	test('sorts descending when the predicate is reversed', () => {
-		expectSuccess('sort_by (fn a b => a > b) [3, 1, 4, 1, 5]', [
-			5, 4, 3, 1, 1,
-		]);
+		expectSuccess('sort_by (>) [3, 1, 4, 1, 5]', [5, 4, 3, 1, 1]);
 	});
 
 	test('sorts tuples by a derived key', () => {

--- a/src/typer/__tests__/sort-by.test.ts
+++ b/src/typer/__tests__/sort-by.test.ts
@@ -1,0 +1,36 @@
+import { test, expect, describe } from 'bun:test';
+import { expectSuccess } from '../../../test/utils';
+
+describe('sort_by (stdlib)', () => {
+	test('sorts numbers ascending with an explicit less-than predicate', () => {
+		expectSuccess('sort_by (fn a b => a < b) [3, 1, 4, 1, 5]', [
+			1, 1, 3, 4, 5,
+		]);
+	});
+
+	test('sorts descending when the predicate is reversed', () => {
+		expectSuccess('sort_by (fn a b => a > b) [3, 1, 4, 1, 5]', [
+			5, 4, 3, 1, 1,
+		]);
+	});
+
+	test('sorts tuples by a derived key', () => {
+		const code = `
+			pairs = [{"c", 1}, {"a", 3}, {"b", 2}];
+			sort_by (fn x y => (
+				{ka, va} = x;
+				{kb, vb} = y;
+				va < vb
+			)) pairs
+		`;
+		expectSuccess(code, [
+			['c', 1],
+			['b', 2],
+			['a', 3],
+		]);
+	});
+
+	test('sort_by on an empty list returns an empty list', () => {
+		expectSuccess('sort_by (fn a b => a < b) ([] : List Float)', []);
+	});
+});

--- a/stdlib.noo
+++ b/stdlib.noo
@@ -293,6 +293,21 @@ sort = fn list => match (head list) (
   Some h => insert_sorted h (sort (tail list))
 );
 
+# Sort with an explicit less-than predicate, for keys with no Ord instance
+# (tuples, records) or a non-default ordering (descending, derived key).
+insert_sorted_by = fn less_than x list => match (head list) (
+  None => [x];
+  Some h =>
+    if less_than x h
+      then cons x list
+      else cons h (insert_sorted_by less_than x (tail list))
+);
+
+sort_by = fn less_than list => match (head list) (
+  None => [];
+  Some h => insert_sorted_by less_than h (sort_by less_than (tail list))
+);
+
 # Association-list helpers: List {key, value} as a small linear map.
 # Deliberately not a dedicated Map/Dict type - this covers the common
 # case (tally, group-by) without adding a new collection primitive;


### PR DESCRIPTION
## Summary
Stacked on #132.

- Operators had no way to be passed as first-class values — `sort_by (<)` parse-errored, forcing `sort_by (fn a b => a < b)` everywhere a bare comparator would do.
- `(op)` now desugars to `fn a b => a op b`, reusing the existing binary-operator typing path (`typeBinary`) rather than re-typing operators' own uncurried 2-param environment bindings — smaller, lower-risk change than making operator env types curried.
- Restricted to the actual `BinaryExpression` operator set: the lexer's `OPERATOR` token also covers `=`, `=>`, `->` (assignment/arrow punctuation, not binary operators), which would otherwise desugar into a malformed AST node if accepted.
- Simplifies `sort_by`'s own tests as the first real usage: `sort_by (<) list` instead of `sort_by (fn a b => a < b) list`.

## Test plan
- [x] `AGENT=1 bun test` — 1185 pass / 8 skip / 0 fail
- [x] `bun run typecheck` — clean
- [x] `node validate_examples.js` — all docs + README pass
- [x] New test file `src/parser/__tests__/operator-sectioning.test.ts` — AST shape, evaluation, use with `sort_by`, unary-minus non-interference, normal-parens non-interference, `(=)` correctly rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TASnoHntaoTfJZpshTGnB