### PR TITLE
Make readFile/writeFile return Result instead of throwing

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ double = fn x => x * 2 : Float -> Float;
 
 # Complex type annotations with effects
 logger = fn msg => print msg : String -> String !write;
-readConfig = fn path => readFile path : String -> String !read;
+readConfig = fn path => readFile path : String -> Result String ReadError !read;
 ```
 
 ### Function Type Syntax
@@ -1039,10 +1039,10 @@ Noolang has a comprehensive effect system that tracks side effects in function t
 # Pure function (no effects)
 sumTwo = fn x y => x + y : Float -> Float -> Float;
 
-# Effectful function
+# Effectful function — readFile returns Result, so handle both cases
 readAndPrint = fn filename => (
   content = readFile filename;
-  print content
+  match content ( Ok text => print text; Err e => print (show e) )
 ) : String -> String !read !write;
 
 # System operations with FFI effects

--- a/docs/language-reference.md
+++ b/docs/language-reference.md
@@ -261,13 +261,22 @@ print "Done!";
 File I/O performs real filesystem effects, so these examples are shown as plain
 text (the documentation validator does not execute them):
 
+File operations return `Result` — a missing file or a failed write is a value
+to handle, not a crash. `readFile : String -> Result String ReadError !read`;
+`writeFile : String -> String -> Result {} WriteError !write`.
+
 ```
 # Read file contents
-content = readFile "example.txt";
-println content;
+match (readFile "example.txt") (
+  Ok content => println content;
+  Err e => println (show e)      # e.g. FileNotFound(example.txt)
+);
 
 # Write to file
-writeFile "output.txt" "Hello from Noolang!";
+match (writeFile "output.txt" "Hello from Noolang!") (
+  Ok _ => println "written";
+  Err e => println (show e)
+)
 ```
 
 #### Logging

--- a/src/evaluator/evaluator-utils.ts
+++ b/src/evaluator/evaluator-utils.ts
@@ -172,6 +172,40 @@ export const isTraitFunctionValue = (
 	value: Value
 ): value is TraitFunctionValue => value.tag === 'trait-function';
 
+// Map node fs errors onto the stdlib ReadError/WriteError variants
+const errnoCode = (error: unknown): string | undefined =>
+	error instanceof Error && 'code' in error
+		? String((error as NodeJS.ErrnoException).code)
+		: undefined;
+
+export const readErrorValue = (
+	error: unknown,
+	path: string
+): ConstructorValue => {
+	switch (errnoCode(error)) {
+		case 'ENOENT':
+			return createConstructor('FileNotFound', [createString(path)]);
+		case 'EACCES':
+		case 'EPERM':
+			return createConstructor('ReadPermissionDenied', [createString(path)]);
+		default:
+			return createConstructor('ReadFailed', [createString(String(error))]);
+	}
+};
+
+export const writeErrorValue = (
+	error: unknown,
+	path: string
+): ConstructorValue => {
+	switch (errnoCode(error)) {
+		case 'EACCES':
+		case 'EPERM':
+			return createConstructor('WritePermissionDenied', [createString(path)]);
+		default:
+			return createConstructor('WriteFailed', [createString(String(error))]);
+	}
+};
+
 export function valueToString(value: Value): string {
 	if (isNumber(value)) {
 		return String(value.value);

--- a/src/evaluator/evaluator.ts
+++ b/src/evaluator/evaluator.ts
@@ -49,6 +49,8 @@ import {
 	createConstructor,
 	createList,
 	createRecord,
+	readErrorValue,
+	writeErrorValue,
 	isNumber,
 	isString,
 	isBool,
@@ -134,6 +136,9 @@ export class Evaluator {
 	private currentFileDir?: string; // Track the directory of the current file being evaluated
 	private fs: typeof defaultFs;
 	private path: typeof defaultPath;
+	// Constructor name -> variant type name, so trait dispatch resolves
+	// `show (Bar "hi")` against the impl for `Foo`, not a phantom `Bar` type
+	private constructorVariants: Map<string, string> = new Map();
 	public traitRegistry: TraitRegistry;
 	private programArgs: string[];
 
@@ -1008,9 +1013,9 @@ export class Evaluator {
 				}
 				try {
 					const content = this.fs.readFileSync(path.value, 'utf-8');
-					return createString(content);
+					return createConstructor('Ok', [createString(content)]);
 				} catch (error) {
-					throw new Error(`Failed to read file: ${error}`);
+					return createConstructor('Err', [readErrorValue(error, path.value)]);
 				}
 			})
 		);
@@ -1026,9 +1031,9 @@ export class Evaluator {
 				}
 				try {
 					this.fs.writeFileSync(path.value, content.value);
-					return createUnit();
+					return createConstructor('Ok', [createUnit()]);
 				} catch (error) {
-					throw new Error(`Failed to write file: ${error}`);
+					return createConstructor('Err', [writeErrorValue(error, path.value)]);
 				}
 			})
 		);
@@ -2872,10 +2877,10 @@ export class Evaluator {
 		if (isRecord(value)) return 'Record';
 		if (isTuple(value)) return 'Tuple';
 		if (isConstructor(value)) {
-			// For ADT constructors, use the constructor name
-			if (value.name === 'Some' || value.name === 'None') return 'Option';
-			if (value.name === 'Ok' || value.name === 'Err') return 'Result';
-			return value.name;
+			// Resolve the constructor to its variant type; fall back to the
+			// constructor name for values whose definition this evaluator never
+			// saw (e.g. constructed by an imported module)
+			return this.constructorVariants.get(value.name) ?? value.name;
 		}
 		return 'Unknown';
 	}
@@ -2883,6 +2888,7 @@ export class Evaluator {
 	private evaluateTypeDefinition(expr: TypeDefinitionExpression): Value {
 		// Type definitions add constructors to the environment
 		for (const _constructor of expr.constructors) {
+			this.constructorVariants.set(_constructor.name, expr.name);
 			if (_constructor.args.length === 0) {
 				// Nullary constructor: just create the constructor value
 				const constructorValue = {

--- a/src/typer/__tests__/effect-inference.test.ts
+++ b/src/typer/__tests__/effect-inference.test.ts
@@ -23,7 +23,9 @@ test('Effect inference - a pure function has no effect', () => {
 });
 
 test('Effect inference - readFile body surfaces !read', () => {
-	expect(typeStr('fn p => readFile p')).toBe('String -> String !read');
+	expect(typeStr('fn p => readFile p')).toBe(
+		'String -> Result String ReadError !read'
+	);
 });
 
 test('Effect inference - effects propagate through a wrapping call', () => {

--- a/src/typer/builtins.ts
+++ b/src/typer/builtins.ts
@@ -218,14 +218,18 @@ export const initializeBuiltins = (state: TypeState): TypeState => {
 	});
 
 	newEnv.set('readFile', {
-		type: functionType([stringType()], stringType(), new Set(['read'])),
+		type: functionType(
+			[stringType()],
+			resultType(stringType(), { kind: 'variant', name: 'ReadError', args: [] }),
+			new Set(['read'])
+		),
 		quantifiedVars: [],
 	});
 
 	newEnv.set('writeFile', {
 		type: functionType(
 			[stringType(), stringType()],
-			unitType(),
+			resultType(unitType(), { kind: 'variant', name: 'WriteError', args: [] }),
 			new Set(['write'])
 		),
 		quantifiedVars: [],

--- a/stdlib.noo
+++ b/stdlib.noo
@@ -202,6 +202,26 @@ implement Show Result (
   )
 );
 
+# File IO failure reasons — readFile/writeFile return Result rather than
+# crashing, matching the safe-division philosophy
+variant ReadError = FileNotFound String | ReadPermissionDenied String | ReadFailed String;
+variant WriteError = WritePermissionDenied String | WriteFailed String;
+
+implement Show ReadError (
+  show = fn err => match err (
+    FileNotFound path => concat "FileNotFound(" (concat path ")");
+    ReadPermissionDenied path => concat "ReadPermissionDenied(" (concat path ")");
+    ReadFailed message => concat "ReadFailed(" (concat message ")")
+  )
+);
+
+implement Show WriteError (
+  show = fn err => match err (
+    WritePermissionDenied path => concat "WritePermissionDenied(" (concat path ")");
+    WriteFailed message => concat "WriteFailed(" (concat message ")")
+  )
+);
+
 # Extract value from Result with default for errors
 result_get_or = fn default res => match res (
   Ok value => value;

--- a/test/features/file-io.test.ts
+++ b/test/features/file-io.test.ts
@@ -1,0 +1,73 @@
+// readFile/writeFile return Result instead of throwing — the types must not
+// claim IO can't fail.
+import { test, expect } from 'bun:test';
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runCode, expectSuccess } from '../utils';
+
+const dir = mkdtempSync(join(tmpdir(), 'noo-file-io-'));
+const existing = join(dir, 'exists.txt');
+const missing = join(dir, 'no-such-file.txt');
+const out = join(dir, 'out.txt');
+const outInMissingDir = join(dir, 'no-such-dir', 'out.txt');
+writeFileSync(existing, 'hello');
+
+test('readFile has type Result String ReadError with !read', () => {
+	const { finalType } = runCode('readFile');
+	expect(finalType).toContain('Result String ReadError');
+	expect(finalType).toContain('!read');
+});
+
+test('readFile on an existing file returns Ok content', () => {
+	expectSuccess(
+		`match (readFile "${existing}") ( Ok content => content; Err e => "err" )`,
+		'hello'
+	);
+});
+
+test('readFile on a missing file returns Err (FileNotFound path), not a crash', () => {
+	expectSuccess(
+		`match (readFile "${missing}") (
+			Ok _ => "ok";
+			Err e => match e (
+				FileNotFound path => path;
+				ReadPermissionDenied _ => "denied";
+				ReadFailed _ => "failed"
+			)
+		)`,
+		missing
+	);
+});
+
+test('writeFile has type Result {} WriteError with !write', () => {
+	const { finalType } = runCode('writeFile');
+	expect(finalType).toContain('Result');
+	expect(finalType).toContain('WriteError');
+	expect(finalType).toContain('!write');
+});
+
+test('writeFile success returns Ok and writes the file', () => {
+	expectSuccess(
+		`match (writeFile "${out}" "written") ( Ok _ => "ok"; Err _ => "err" )`,
+		'ok'
+	);
+	expect(readFileSync(out, 'utf-8')).toBe('written');
+});
+
+test('writeFile into a missing directory returns Err, not a crash', () => {
+	expectSuccess(
+		`match (writeFile "${outInMissingDir}" "x") (
+			Ok _ => "ok";
+			Err e => match e (
+				WritePermissionDenied _ => "denied";
+				WriteFailed _ => "failed"
+			)
+		)`,
+		'failed'
+	);
+});
+
+test('cleanup', () => {
+	rmSync(dir, { recursive: true, force: true });
+});

--- a/test/features/trait-dispatch-user-variants.test.ts
+++ b/test/features/trait-dispatch-user-variants.test.ts
@@ -1,0 +1,26 @@
+// Runtime trait dispatch must resolve by the variant's *type* name, not the
+// constructor name — a Show impl for `Foo` must fire for value `Bar "hi"`.
+import { test } from 'bun:test';
+import { expectSuccess } from '../utils';
+
+test('trait dispatch works for user-defined variant with payload', () => {
+	expectSuccess(
+		`variant Foo = Bar String | Baz;
+		 implement Show Foo (show = fn f => match f (Bar s => s; Baz => "baz"));
+		 show (Bar "hi")`,
+		'hi'
+	);
+});
+
+test('trait dispatch works for nullary constructors of user variants', () => {
+	expectSuccess(
+		`variant Light = Red | Amber | Green;
+		 implement Show Light (show = fn l => match l (Red => "stop"; Amber => "wait"; Green => "go"));
+		 show Amber`,
+		'wait'
+	);
+});
+
+test('trait dispatch works for stdlib file-IO error variants', () => {
+	expectSuccess(`show (FileNotFound "/x")`, 'FileNotFound(/x)');
+});


### PR DESCRIPTION
## Summary
- `readFile : String -> Result String ReadError !read` and `writeFile : String -> String -> Result {} WriteError !write` — file IO failures are now values to match on, not evaluator crashes. Errno mapping: `ENOENT` → `FileNotFound`, `EACCES`/`EPERM` → `*PermissionDenied`, else `ReadFailed`/`WriteFailed`. `Show` impls included for both error variants.
- Fixes an evaluator bug this exposed: **runtime trait dispatch resolved by constructor name, not variant type name** (hardcoded exceptions for Option/Result only), so `implement Show Foo` never fired for `Bar "hi"` — every user-defined variant's trait impl silently returned the unapplied trait function. Dispatch now consults a constructor→variant map populated when type definitions evaluate.
- Docs updated (README annotation examples, language-reference File Operations section).

## Known follow-up
Cross-module merging of the constructor→variant map (imported multi-constructor variants with trait impls) is tracked separately.

## Test plan
- New `test/features/file-io.test.ts`: Ok/Err round-trips against real temp files, missing-file and missing-directory failure paths, type assertions.
- New `test/features/trait-dispatch-user-variants.test.ts`: dispatch on user variants with payloads, nullary constructors, and the new stdlib error variants — red before the dispatch fix.
- Full suite 1217 pass, `bun run typecheck` clean, `node validate_examples.js` exits 0.
- Hand-verified inferred types per repo hazard note: `readFile` ⇒ `String -> Result String ReadError !read`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TASnoHntaoTfJZpshTGnB