### PR TITLE
Give exec an honest ExecError type and safe argument passing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1052,7 +1052,7 @@ runCommand = fn cmd args => exec cmd args : String -> List String -> Result Stri
 result = exec "echo" ["Hello World"];
 match result (
   Ok output => print output;
-  Err error => print error
+  Err error => print (show error)   # CommandFailed code stderr | ExecFailed message
 );
 ```
 

--- a/src/evaluator/evaluator.ts
+++ b/src/evaluator/evaluator.ts
@@ -1,6 +1,6 @@
 import * as defaultFs from 'node:fs';
 import * as defaultPath from 'node:path';
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import type {
 	Expression,
 	Program,
@@ -1114,22 +1114,26 @@ export class Evaluator {
 				}
 
 				try {
-					// Build command with arguments
-					const fullCommand = argStrings.length > 0 
-						? `${command.value} ${argStrings.map(arg => `"${arg}"`).join(' ')}`
-						: command.value;
-					
-					const output = execSync(fullCommand, { 
+					const output = execFileSync(command.value, argStrings, {
 						encoding: 'utf8',
-						stdio: 'pipe'
+						stdio: 'pipe',
 					});
-					
-					// Return Ok(output)
 					return createConstructor('Ok', [createString(output.toString())]);
 				} catch (error: any) {
-					// Return Err(error message)
-					const errorMsg = error.message || 'Process execution failed';
-					return createConstructor('Err', [createString(errorMsg)]);
+					// A numeric status means the process ran and exited nonzero;
+					// anything else (spawn failure, signal kill) is ExecFailed
+					if (typeof error?.status === 'number') {
+						return createConstructor('Err', [
+							createConstructor('CommandFailed', [
+								createNumber(error.status),
+								createString(String(error.stderr ?? '')),
+							]),
+						]);
+					}
+					const errorMsg = error?.message || 'Process execution failed';
+					return createConstructor('Err', [
+						createConstructor('ExecFailed', [createString(errorMsg)]),
+					]);
 				}
 			})
 		);

--- a/src/typer/builtins.ts
+++ b/src/typer/builtins.ts
@@ -644,10 +644,14 @@ export const initializeBuiltins = (state: TypeState): TypeState => {
 	newEnv.set('exec', {
 		type: functionType(
 			[stringType(), listTypeWithElement(stringType())],
-			resultType(stringType(), typeVariable('ExecError')),
+			resultType(stringType(), {
+				kind: 'variant',
+				name: 'ExecError',
+				args: [],
+			}),
 			new Set(['ffi'])
 		),
-		quantifiedVars: ['ExecError'],
+		quantifiedVars: [],
 	});
 
 	const newState = { ...state, environment: newEnv };

--- a/stdlib.noo
+++ b/stdlib.noo
@@ -207,6 +207,17 @@ implement Show Result (
 variant ReadError = FileNotFound String | ReadPermissionDenied String | ReadFailed String;
 variant WriteError = WritePermissionDenied String | WriteFailed String;
 
+# Process failure: CommandFailed exitCode stderr (the process ran and exited
+# nonzero) vs ExecFailed message (the process could not run at all)
+variant ExecError = CommandFailed Float String | ExecFailed String;
+
+implement Show ExecError (
+  show = fn err => match err (
+    CommandFailed code stderr => concat "CommandFailed(" (concat (show code) (concat ", " (concat stderr ")")));
+    ExecFailed message => concat "ExecFailed(" (concat message ")")
+  )
+);
+
 implement Show ReadError (
   show = fn err => match err (
     FileNotFound path => concat "FileNotFound(" (concat path ")");

--- a/test/builtins/exec.test.ts
+++ b/test/builtins/exec.test.ts
@@ -29,18 +29,17 @@ describe('exec builtin function', () => {
 		}));
 	});
 
-	test('exec with nonexistent command should return Err', () => {
+	test('exec with nonexistent command should return Err (ExecFailed message)', () => {
 		expectSuccess(`
 			result = exec "nonexistentcommand12345" [];
-			result
-		`, expect.objectContaining({
-			tag: 'constructor',
-			name: 'Err',
-			args: [expect.objectContaining({
-				tag: 'string',
-				value: expect.stringContaining('Command failed')
-			})]
-		}));
+			match result (
+				Ok _ => "ok";
+				Err e => match e (
+					CommandFailed code stderr => "ran anyway";
+					ExecFailed message => message
+				)
+			)
+		`, expect.stringContaining('nonexistentcommand12345'));
 	});
 
 	test('exec type signature should be correct', () => {

--- a/test/features/exec.test.ts
+++ b/test/features/exec.test.ts
@@ -1,0 +1,50 @@
+// exec's error type must be a real variant, not a phantom type variable —
+// `Result String a` lets a match treat the Err payload as any type at all.
+import { test, expect } from 'bun:test';
+import { runCode, expectSuccess } from '../utils';
+
+test('exec has a concrete ExecError type, not a type variable', () => {
+	const { finalType } = runCode('exec');
+	expect(finalType).toContain('Result String ExecError');
+	expect(finalType).toContain('!ffi');
+});
+
+test('exec success returns Ok stdout', () => {
+	expectSuccess(
+		`match (exec "printf" ["hi"]) ( Ok out => out; Err _ => "err" )`,
+		'hi'
+	);
+});
+
+test('exec nonzero exit returns Err (CommandFailed code stderr)', () => {
+	expectSuccess(
+		`match (exec "false" []) (
+			Ok _ => -1;
+			Err e => match e (
+				CommandFailed code stderr => code;
+				ExecFailed _ => -2
+			)
+		)`,
+		1
+	);
+});
+
+test('exec failure carries stderr text', () => {
+	expectSuccess(
+		`match (exec "ls" ["/definitely-no-such-path-xyz"]) (
+			Ok _ => "ok";
+			Err e => match e (
+				CommandFailed code stderr => stderr;
+				ExecFailed message => "spawn"
+			)
+		)`,
+		expect.stringContaining('No such file')
+	);
+});
+
+test('ExecError has a Show implementation', () => {
+	expectSuccess(
+		`match (exec "false" []) ( Ok _ => "ok"; Err e => show e )`,
+		expect.stringContaining('CommandFailed')
+	);
+});


### PR DESCRIPTION
## Summary
- `ExecError` was a phantom: an unconstrained quantified type variable, so matches against the `Err` payload typechecked at *any* type (String and Float branches both passed) while the runtime value was always a bare string. It is now a real stdlib variant: `CommandFailed exitCode stderr` (process ran, exited nonzero) vs `ExecFailed message` (process couldn't run), with a `Show` impl.
- Fixed the native's argument passing: it interpolated args into a shell string with hand-rolled quotes — broken on embedded quotes, injection-prone. Now `execFileSync(command, args)`, matching the declared `List String` API. Behavioral note: no shell interpretation of metacharacters anymore; args go to the process verbatim.
- Exit codes and stderr are now available to noolang programs — needed by the planned test-runner's per-file isolation, useful generally.

## Test plan
- New `test/features/exec.test.ts`: concrete type assertion (red before fix), Ok path, nonzero-exit → `CommandFailed code stderr`, stderr capture, `Show`.
- Updated stale expectation in `test/builtins/exec.test.ts` (nonexistent command → `ExecFailed` with the command name in the message).
- Full suite 1222 pass, typecheck clean, doc validation exits 0.
- Hand-verified: `exec` ⇒ `String List String -> Result String ExecError !ffi`; `show` on a failure renders `CommandFailed(1, )`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TASnoHntaoTfJZpshTGnB