### PR TITLE
Resolve an entry file's relative imports from its own directory

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -192,7 +192,11 @@ async function main() {
 			const lexer = new Lexer(code);
 			const tokens = lexer.tokenize();
 			const program = parse(tokens);
-			const { program: decoratedProgram, state } = typeAndDecorate(program);
+			const { program: decoratedProgram, state } = typeAndDecorate(
+				program,
+				undefined,
+				path.dirname(fullPath)
+			);
 			console.log('Types:');
 			decoratedProgram.statements.forEach((stmt, i) => {
 				console.log(
@@ -284,7 +288,11 @@ async function main() {
 			const lexer = new Lexer(code);
 			const tokens = lexer.tokenize();
 			const program = parse(tokens);
-			const { program: decoratedProgram, state } = typeAndDecorate(program);
+			const { program: decoratedProgram, state } = typeAndDecorate(
+				program,
+				undefined,
+				path.dirname(fullPath)
+			);
 			console.log('Type AST (what typeAndDecorate returns):');
 			console.log(
 				JSON.stringify({ program: decoratedProgram, state }, null, 2)
@@ -311,7 +319,11 @@ async function main() {
 			const lexer = new Lexer(combinedCode);
 			const tokens = lexer.tokenize();
 			const program = parse(tokens);
-			const { program: decoratedProgram, state } = typeAndDecorate(program);
+			const { program: decoratedProgram, state } = typeAndDecorate(
+				program,
+				undefined,
+				path.dirname(fullPath)
+			);
 
 			// Get the type of the last statement (which is our symbol reference)
 			if (decoratedProgram.statements.length > 0) {
@@ -436,7 +448,11 @@ async function main() {
 		const program = parse(tokens);
 		const parseTime = performance.now();
 
-		const { program: decoratedProgram, state } = typeAndDecorate(program);
+		const { program: decoratedProgram, state } = typeAndDecorate(
+			program,
+			undefined,
+			path.dirname(fullPath)
+		);
 		const typeTime = performance.now();
 
 		const evaluator = new Evaluator({
@@ -444,7 +460,7 @@ async function main() {
 			programArgs: fileArgs.slice(1),
 		});
 
-		const finalResult = evaluator.evaluateProgram(decoratedProgram);
+		const finalResult = evaluator.evaluateProgram(decoratedProgram, fullPath);
 		const evalTime = performance.now();
 
 		const valueStr = formatValue(finalResult.finalResult);

--- a/src/typer/decoration.ts
+++ b/src/typer/decoration.ts
@@ -8,7 +8,10 @@ import { substitute } from './substitute';
 // Decorate AST nodes with inferred types - now uses single-pass typing
 export const typeAndDecorate = (
 	program: Program,
-	initialState?: TypeState
+	initialState?: TypeState,
+	// Directory of the file being typed, so relative imports resolve
+	// file-relative (per the language reference), not CWD-relative
+	currentDir?: string
 ): {
 	program: Program;
 	type: Type;
@@ -16,6 +19,9 @@ export const typeAndDecorate = (
 	state: TypeState;
 } => {
 	let state = initialState || createTypeState();
+	if (currentDir) {
+		state = { ...state, currentDir };
+	}
 	// Always ensure builtins and stdlib are loaded, regardless of whether initialState was provided
 	if (!initialState || !state.traitRegistry.definitions.size) {
 		state = initializeBuiltins(state);

--- a/test/integration/entry-file-relative-import.test.ts
+++ b/test/integration/entry-file-relative-import.test.ts
@@ -1,0 +1,38 @@
+// Relative imports resolve against the importing file's directory, per
+// docs/language-reference.md §Import System — not against the process CWD.
+// Runs the real CLI from a different CWD to prove it.
+import { test, expect } from 'bun:test';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const repoRoot = resolve(import.meta.dir, '..', '..');
+const cli = join(repoRoot, 'src', 'cli.ts');
+
+const dir = mkdtempSync(join(tmpdir(), 'noo-entry-import-'));
+writeFileSync(join(dir, 'dep.noo'), '{@answer 42}');
+writeFileSync(
+	join(dir, 'main.noo'),
+	'{@answer} = import "./dep";\nanswer'
+);
+
+function runCli(cliArgs: string[]): string {
+	return execFileSync('bun', [cli, ...cliArgs], {
+		cwd: repoRoot, // deliberately not `dir`
+		encoding: 'utf8',
+		env: { ...process.env, NO_COLOR: '1' },
+	});
+}
+
+test('running a file resolves its relative imports from the file dir, not CWD', () => {
+	expect(runCli([join(dir, 'main.noo')])).toContain('42');
+});
+
+test('--types-file resolves relative imports from the file dir, not CWD', () => {
+	expect(runCli(['--types-file', join(dir, 'main.noo')])).toContain('Float');
+});
+
+test('cleanup', () => {
+	rmSync(dir, { recursive: true, force: true });
+});

--- a/validate_examples.js
+++ b/validate_examples.js
@@ -2,7 +2,6 @@
 
 import fs from 'fs';
 import path from 'path';
-import os from 'os';
 import { execSync } from 'child_process';
 
 // Run a markdown file directly using CLI's literate mode
@@ -53,7 +52,9 @@ function extractNoolangBlocks(filePath) {
 // must not be validated as a single concatenated program (see issue #102).
 function runMarkdownPerBlock(filePath) {
 	const blocks = extractNoolangBlocks(filePath);
-	const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'noolang-blocks-'));
+	// Materialize blocks inside the repo: imports resolve relative to the
+	// block file, and bare specifiers need the repo's noolang.json in scope
+	const tmp = fs.mkdtempSync(path.join('.', '.noolang-blocks-'));
 	const failures = [];
 	for (const block of blocks) {
 		const f = path.join(tmp, 'block.noo');


### PR DESCRIPTION
## Summary
- `bun src/cli.ts /path/to/main.noo` from any other CWD failed on `import "./sibling"` — the CLI never told the typer or evaluator where the entry file lived, contradicting the language reference ("relative to the importing module"). Found during the test-framework spike; the planned runner's generated entry module depends on documented behavior.
- `typeAndDecorate` gains an optional `currentDir` seeding `TypeState.currentDir`; the CLI passes it in all file-taking modes (run, `--types-file`, `--type-ast-file`, `--symbol-type`) and hands the path to `evaluateProgram` so the evaluator agrees.
- Doc-validator fix this exposed: README blocks were materialized in an OS temp dir and only resolved `import "examples/…"` because resolution leaked from CWD. Blocks now materialize inside the repo, where the import map is genuinely in scope.

## Test plan
- New `test/integration/entry-file-relative-import.test.ts` spawns the real CLI from the repo root against files in an OS temp dir (red before fix) — run mode and `--types-file`.
- Full suite 1225 pass, typecheck clean, doc validation exits 0 (all docs + 57 README blocks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TASnoHntaoTfJZpshTGnB