### PR TITLE
Enforce effect subsumption when passing functions as arguments

### DIFF
--- a/src/typer/__tests__/effect-inference.test.ts
+++ b/src/typer/__tests__/effect-inference.test.ts
@@ -53,3 +53,41 @@ test('Effect enforcement - a matching effect annotation is accepted', () => {
 test('Effect enforcement - over-declaring effects (conservative) is allowed', () => {
 	expect(typeStr('fn x => x : a -> a !write')).toBe('a -> a !write');
 });
+
+// --- Effect enforcement at application: passing an effectful function where a
+// pure function type is expected must be rejected, or effects launder through
+// higher-order boundaries (constructor payloads included) ---
+
+test('Effect enforcement - effectful thunk rejected by pure constructor payload', () => {
+	expect(() =>
+		typeChecks(
+			'variant T = Case ({} -> Float); Case (fn _ => (print "hi"; 2))'
+		)
+	).toThrow(/effect/i);
+});
+
+test('Effect enforcement - constructor payload declaring the effect accepts it', () => {
+	expect(typeStr('variant T = Case ({} -> Float !write); Case (fn _ => (print "hi"; 2))')).toBe(
+		'T'
+	);
+});
+
+test('Effect enforcement - effectful argument rejected by pure annotated parameter', () => {
+	expect(() =>
+		typeChecks(
+			'callp = (fn f => f {}) : ({} -> Float) -> Float; callp (fn _ => (print "x"; 2))'
+		)
+	).toThrow(/effect/i);
+});
+
+test('Effect enforcement - pure argument accepted by effect-declaring parameter', () => {
+	expect(typeStr('callw = (fn f => f {}) : ({} -> Float !write) -> Float; callw (fn _ => 2)')).toBe(
+		'Float'
+	);
+});
+
+test('Effect enforcement - unannotated HOF still propagates effects', () => {
+	expect(typeStr('g = fn f => f {}; fn u => g (fn _ => (print "x"; 2))')).toBe(
+		'a -> Float !write'
+	);
+});

--- a/src/typer/effects-utils.ts
+++ b/src/typer/effects-utils.ts
@@ -1,4 +1,4 @@
-import type { Effect } from '../ast';
+import type { Effect, Type } from '../ast';
 
 // Helper: Format effects as string for type display
 export function formatEffectsString(effects: Set<Effect>): string {
@@ -7,3 +7,35 @@ export function formatEffectsString(effects: Set<Effect>): string {
 		.map(e => `!${e}`)
 		.join(' ')}`;
 }
+
+// True when a type contains no type variables — i.e. it was written down
+// rather than inferred fresh. Effect sets carry no polymorphism marker, so an
+// empty set on an inferred function type means "unconstrained" while on a
+// concrete one it means "declared pure"; only the latter is enforceable.
+export const isFullyConcrete = (type: Type): boolean => {
+	switch (type.kind) {
+		case 'variable':
+			return false;
+		case 'function':
+			return type.params.every(isFullyConcrete) && isFullyConcrete(type.return);
+		case 'list':
+			return isFullyConcrete(type.element);
+		case 'variant':
+			return type.args.every(isFullyConcrete);
+		case 'tuple':
+			return type.elements.every(isFullyConcrete);
+		default:
+			return true;
+	}
+};
+
+// Collect the latent effects along a (possibly curried) function type's spine.
+export const collectSpineEffects = (type: Type): Set<Effect> => {
+	const effects = new Set<Effect>();
+	let t: Type = type;
+	while (t.kind === 'function') {
+		if (t.effects) for (const e of t.effects) effects.add(e);
+		t = t.return;
+	}
+	return effects;
+};

--- a/src/typer/regular-function-application.ts
+++ b/src/typer/regular-function-application.ts
@@ -11,7 +11,8 @@ import {
 	typeToString,
 	propagateConstraintToTypeVariable,
 } from './helpers';
-import { functionApplicationError } from './type-errors';
+import { functionApplicationError, createTypeError } from './type-errors';
+import { collectSpineEffects, isFullyConcrete } from './effects-utils';
 import {
 	type TypeState,
 	type TypeResult,
@@ -89,6 +90,40 @@ export function handleRegularFunctionApplication(
 			// Pass constraint information if available
 			...(functionConstraints && { constraintContext: functionConstraints }),
 		};
+
+		// Effect subsumption: a function argument may perform fewer effects than
+		// the parameter declares, never more — otherwise effects launder through
+		// higher-order boundaries (annotated HOFs, constructor payloads). Only
+		// checked when the parameter is a concrete function type; a parameter
+		// type variable takes the argument's effects wholesale via unification.
+		if (
+			expectedParam.kind === 'function' &&
+			actualArg.kind === 'function' &&
+			isFullyConcrete(expectedParam)
+		) {
+			const declared = collectSpineEffects(expectedParam);
+			const performed = collectSpineEffects(actualArg);
+			const omitted = [...performed].filter(e => !declared.has(e));
+			if (omitted.length > 0) {
+				throwTypeError(
+					location =>
+						createTypeError(
+							`Function argument performs effect${
+								omitted.length > 1 ? 's' : ''
+							} !${omitted.join(' !')} not declared by the parameter type ${typeToString(
+								expectedParam,
+								currentState.substitution
+							)}`,
+							{},
+							location
+						),
+					{
+						line: expr.location?.start.line || 1,
+						column: expr.location?.start.column || 1,
+					}
+				);
+			}
+		}
 
 		currentState = unify(
 			actualFuncType.params[i],

--- a/src/typer/type-inference.ts
+++ b/src/typer/type-inference.ts
@@ -67,6 +67,7 @@ import {
 	constraintsEqual,
 } from './helpers';
 import { addConstraint, resolveVarName } from './constraint-store';
+import { collectSpineEffects } from './effects-utils';
 import {
 	composeConstraintChain,
 	extractResultTypeVar,
@@ -1566,16 +1567,6 @@ const resolveTypeAliases = (
 	}
 };
 
-// Collect the latent effects along a (possibly curried) function type's spine.
-const collectSpineEffects = (type: Type): Set<Effect> => {
-	const effects = new Set<Effect>();
-	let t: Type = type;
-	while (t.kind === 'function') {
-		if (t.effects) for (const e of t.effects) effects.add(e);
-		t = t.return;
-	}
-	return effects;
-};
 
 export const typeTyped = (
 	expr: TypedExpression,


### PR DESCRIPTION
## Summary
- Found during the test-framework spike: `variant T = Case ({} -> Float); Case (fn _ => (print "hi"; 2))` typechecked — the `!write` effect laundered through the constructor payload and the extracted thunk ran as if pure. Same hole for any annotated higher-order parameter (`callp = (fn f => f {}) : ({} -> Float) -> Float` accepted an effectful argument). The direct-annotation path already rejected exactly this omission; application didn't.
- Fix: at function application, a function-typed argument must perform no effect the expected parameter type omits (over-declaring remains legal), mirroring the annotation rule.
- Scope guard: enforcement only fires when the expected parameter type is **fully concrete**. Effect sets have no polymorphism marker — an empty set on an inferred `a -> b` means "unconstrained," not "pure" — so generic HOFs (`g = fn f => f {}`) keep accepting effectful arguments and propagating their effects via accumulation, as before. Incomplete over incorrect; effect variables would be the complete fix and are out of scope.
- `collectSpineEffects` moved to `effects-utils.ts` (shared with the annotation path); new `isFullyConcrete` helper alongside it.

## Test plan
- Five new cases in `src/typer/__tests__/effect-inference.test.ts`: laundering via constructor payload rejected (red before), laundering via annotated HOF param rejected (red before), payload declaring the effect accepts it, pure arg accepted by effect-declaring param, unannotated HOF still propagates (`a -> Float !write`).
- Full suite 1230 pass, typecheck clean, doc validation exits 0.
- Hand-verified per repo hazard note with `--types` on both the rejection and acceptance cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TASnoHntaoTfJZpshTGnB