### PR TITLE
Merge imported modules' constructor→variant map for trait dispatch

### DIFF
--- a/src/evaluator/evaluator.ts
+++ b/src/evaluator/evaluator.ts
@@ -2442,6 +2442,15 @@ export class Evaluator {
 			const realpath = resolveModulePath(expr.path, this.currentFileDir);
 			const cached = loadModule(realpath);
 
+			// Trait dispatch resolves a value's constructor to its variant type
+			// name; imported variants were defined in the module's own evaluator,
+			// so their constructor→variant entries must arrive via the cache
+			for (const [typeName, adtEntry] of cached.adtDiff) {
+				for (const ctorName of adtEntry.constructors.keys()) {
+					this.constructorVariants.set(ctorName, typeName);
+				}
+			}
+
 			// Merge the imported module's trait implementations (§4) into this
 			// evaluator's traitRegistry so cross-module dispatch works. Each impl
 			// carries BOTH its AST `functions` and its pre-evaluated

--- a/test/integration/cross-module-trait-dispatch.test.ts
+++ b/test/integration/cross-module-trait-dispatch.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Runtime trait dispatch on variants defined in an imported module.
+ *
+ * Dispatch resolves a value's constructor to its variant type name via the
+ * evaluator's constructor→variant map. That map is populated when a type
+ * definition is *evaluated locally* — for imported variants it must arrive
+ * through the module cache merge, or dispatch falls back to the constructor
+ * name and misses the impl (multi-constructor variants misdispatch; only
+ * single-constructor variants whose constructor happens to share the type's
+ * name work by coincidence).
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { expectSuccess } from '../utils';
+import { clearModuleCache } from '../../src/module-loader';
+
+const TMPDIR = path.join(process.cwd(), '.test-tmp-cross-module-dispatch');
+
+function writeTmp(relPath: string, content: string): string {
+	const fullPath = path.join(TMPDIR, relPath);
+	fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+	fs.writeFileSync(fullPath, content, 'utf8');
+	return fullPath;
+}
+
+function nooPath(relPath: string): string {
+	return path.join(TMPDIR, relPath).replace(/\.noo$/, '');
+}
+
+beforeEach(() => {
+	fs.mkdirSync(TMPDIR, { recursive: true });
+	clearModuleCache();
+});
+
+afterEach(() => {
+	fs.rmSync(TMPDIR, { recursive: true, force: true });
+});
+
+describe('cross-module trait dispatch on imported variants', () => {
+	beforeEach(() => {
+		writeTmp(
+			'shapes.noo',
+			`
+variant Shape = Circle Float | Square Float;
+implement Show Shape (
+  show = fn s => match s (
+    Circle r => concat "circle:" (show r);
+    Square w => concat "square:" (show w)
+  )
+);
+{@circle fn r => Circle r, @square fn w => Square w}
+`
+		);
+	});
+
+	test('show dispatches on an imported multi-constructor variant value', () => {
+		expectSuccess(
+			`
+{@circle} = import "${nooPath('shapes.noo')}";
+show (circle 2)
+`,
+			'circle:2'
+		);
+	});
+
+	test('both constructors of the imported variant dispatch to the same impl', () => {
+		expectSuccess(
+			`
+{@circle, @square} = import "${nooPath('shapes.noo')}";
+concat (show (circle 1)) (concat " " (show (square 3)))
+`,
+			'circle:1 square:3'
+		);
+	});
+});


### PR DESCRIPTION
## Summary
- Follow-up to #135's dispatch fix: the constructor→variant map was per-evaluator, populated only by locally evaluated type definitions. A variant defined in an imported module registered in the module's own evaluator, so the consumer's dispatch fell back to constructor-name lookup — `implement Show Shape` never fired for `Circle 2` (multi-constructor imported variants misdispatched; single-constructor ones worked coincidentally when constructor name == type name).
- The module cache's `adtDiff` already carries `typeName → constructors`; `evaluateImport` now folds it into the consumer's map alongside the existing `traitImplDiff` merge. No new cache plumbing needed.

## Test plan
- New `test/integration/cross-module-trait-dispatch.test.ts`: module exports a two-constructor `Shape` with a `Show` impl; consumer imports and `show`s both constructors (red before fix, both tests).
- Full suite 1227 pass, typecheck clean, doc validation exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TASnoHntaoTfJZpshTGnB