### PR TITLE
Add exit builtin (Float -> {} !ffi)

### DIFF
--- a/src/evaluator/evaluator.ts
+++ b/src/evaluator/evaluator.ts
@@ -1006,6 +1006,16 @@ export class Evaluator {
 		);
 
 		this.environment.set(
+			'exit',
+			createNativeFunction('exit', (code: Value) => {
+				if (!isNumber(code)) {
+					throw new Error('exit requires a number');
+				}
+				process.exit(code.value);
+			})
+		);
+
+		this.environment.set(
 			'readFile',
 			createNativeFunction('readFile', (path: Value) => {
 				if (!isString(path)) {

--- a/src/typer/builtins.ts
+++ b/src/typer/builtins.ts
@@ -217,6 +217,12 @@ export const initializeBuiltins = (state: TypeState): TypeState => {
 		quantifiedVars: ['a'],
 	});
 
+	// Process termination — never returns; {} is the closest honest return type
+	newEnv.set('exit', {
+		type: functionType([floatType()], unitType(), new Set(['ffi'])),
+		quantifiedVars: [],
+	});
+
 	newEnv.set('readFile', {
 		type: functionType(
 			[stringType()],

--- a/test/features/exit.test.ts
+++ b/test/features/exit.test.ts
@@ -1,0 +1,38 @@
+// exit terminates the process with the given code — needed by any noolang
+// program that reports status to a shell (the test runner most immediately).
+import { test, expect } from 'bun:test';
+import { execFileSync } from 'node:child_process';
+import { join, resolve } from 'node:path';
+import { runCode } from '../utils';
+
+const repoRoot = resolve(import.meta.dir, '..', '..');
+const cli = join(repoRoot, 'src', 'cli.ts');
+
+test('exit has type Float -> {} with an effect', () => {
+	const { finalType } = runCode('exit');
+	expect(finalType).toContain('Float');
+	expect(finalType).toContain('!ffi');
+});
+
+test('exit terminates the process with the given code', () => {
+	let status = 0;
+	try {
+		execFileSync('bun', [cli, '-e', 'exit 3'], {
+			cwd: repoRoot,
+			encoding: 'utf8',
+			stdio: 'pipe',
+		});
+	} catch (error: any) {
+		status = error.status;
+	}
+	expect(status).toBe(3);
+});
+
+test('exit 0 exits cleanly even mid-program', () => {
+	const out = execFileSync('bun', [cli, '-e', 'x = print "before"; exit 0'], {
+		cwd: repoRoot,
+		encoding: 'utf8',
+		stdio: 'pipe',
+	});
+	expect(out).toContain('before');
+});


### PR DESCRIPTION
## Summary
- `exit : Float -> {} !ffi` — terminates the process with the given code. Previously a noolang program could not report status to its shell. Categorized `!ffi` alongside `exec` as a process-level operation; it never returns, and `{}` is the closest honest return type the effect system can express.
- Decided in the test-framework plan (docs-wip/TESTING_FRAMEWORK_PLAN.md): a public builtin rather than a CLI-shim mapping, per the shipped-but-unprivileged principle — the self-hosted runner must be buildable with public capabilities only.

## Test plan
- `test/features/exit.test.ts`: type assertion (`Float -> {} !ffi`), subprocess exits with code 3 on `exit 3`, `exit 0` exits cleanly mid-program. Red before implementation.
- Full suite 1228 pass, typecheck clean, doc validation exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TASnoHntaoTfJZpshTGnB