### PR TITLE
Add the std/test runner core: run_tree, format_result, run_all

### DIFF
--- a/std/test.noo
+++ b/std/test.noo
@@ -64,6 +64,81 @@ expect_err = fn res => match res (
 expect_all = fn expectations =>
   reduce (fn acc e => match acc (Pass => e; Fail info => Fail info)) Pass expectations;
 
+# ========================================
+# RUNNER
+# ========================================
+
+# The executed mirror of a Test tree. Execution (run_tree) is effectful —
+# thunks carry the full effect row; everything after it is pure.
+variant TestResult =
+    CaseResult String Expectation
+  | GroupResult String (List TestResult);
+
+run_tree = fn t => match t (
+  Case name thunk => CaseResult name (thunk {});
+  Group name tests => GroupResult name (list_map run_tree tests)
+);
+
+result_counts = fn result => match result (
+  CaseResult _ e => match e (
+    Pass => {@passed 1, @failed 0};
+    Fail _ => {@passed 0, @failed 1}
+  );
+  GroupResult _ results =>
+    reduce
+      (fn acc r => (
+        counts = result_counts r;
+        {@passed (@passed acc) + (@passed counts), @failed (@failed acc) + (@failed counts)}
+      ))
+      {@passed 0, @failed 0}
+      results
+);
+
+indent = fn depth =>
+  if depth == 0 then "" else concat "  " (indent (depth - 1));
+
+# Failure detail lines, indented under the case mark
+format_failure = fn depth info => (
+  pad = concat (indent depth) "    ";
+  expected = @expected info;
+  actual = @actual info;
+  match {expected, actual} (
+    {Some e, Some a} =>
+      concat pad (concat "expected: " (concat e (concat "\n" (concat pad (concat "actual:   " a)))));
+    _ => concat pad (@message info)
+  )
+);
+
+format_at = fn depth result => match result (
+  CaseResult name e => match e (
+    Pass => concat (indent depth) (concat "✓ " name);
+    Fail info =>
+      concat (indent depth) (concat "✗ " (concat name (concat "\n" (format_failure depth info))))
+  );
+  GroupResult name results =>
+    concat (indent depth) (concat name (concat "\n"
+      (join "\n" (list_map (format_at (depth + 1)) results))))
+);
+
+format_result = format_at 0;
+
+# Print each suite's report and a final summary; return counts so the caller
+# (not the runner) decides the process exit code
+run_all = fn suites => (
+  totals = reduce
+    (fn acc entry => (
+      result = run_tree (@suite entry);
+      _p1 = println (@path entry);
+      _p2 = println (format_result result);
+      counts = result_counts result;
+      {@passed (@passed acc) + (@passed counts), @failed (@failed acc) + (@failed counts)}
+    ))
+    {@passed 0, @failed 0}
+    suites;
+  _summary = println (concat (show (@passed totals)) (concat " passed, " (concat (show (@failed totals)) " failed")));
+  totals
+);
+
 {
   @test_case test_case,
   @group group,
@@ -73,5 +148,9 @@ expect_all = fn expectations =>
   @expect_ok expect_ok,
   @expect_err expect_err,
   @expect_all expect_all,
-  @fail fail
+  @fail fail,
+  @run_tree run_tree,
+  @format_result format_result,
+  @result_counts result_counts,
+  @run_all run_all
 }

--- a/test/features/std-test-runner.test.ts
+++ b/test/features/std-test-runner.test.ts
@@ -1,0 +1,93 @@
+// std/test runner: run_tree executes the Test tree into a TestResult,
+// format_result renders the report (pure), result_counts aggregates (pure),
+// run_all prints and returns counts. Exit codes are the caller's job.
+import { test, expect } from 'bun:test';
+import { execFileSync } from 'node:child_process';
+import { join, resolve } from 'node:path';
+import { expectSuccess } from '../utils';
+
+const repoRoot = resolve(import.meta.dir, '..', '..');
+const cli = join(repoRoot, 'src', 'cli.ts');
+
+const importAll = `{@test_case, @group, @expect_eq, @fail, @run_tree, @format_result, @result_counts, @run_all} = import "std/test";`;
+
+const sampleSuite = `
+suite = group "math" [
+  test_case "adds" (fn _ => expect_eq 4 (2 + 2)),
+  test_case "breaks" (fn _ => expect_eq 7 8),
+  group "edge" [
+    test_case "zero" (fn _ => expect_eq 0 0)
+  ]
+];`;
+
+test('run_tree executes thunks and mirrors the tree shape', () => {
+	expectSuccess(
+		`
+${importAll}
+${sampleSuite}
+match (run_tree suite) (
+  GroupResult name results => concat name (concat ":" (show (length results)));
+  CaseResult _ _ => "unexpected"
+)`,
+		'math:3'
+	);
+});
+
+test('result_counts aggregates passes and failures across nesting', () => {
+	expectSuccess(
+		`
+${importAll}
+${sampleSuite}
+counts = result_counts (run_tree suite);
+concat (show (@passed counts)) (concat "/" (show (@failed counts)))`,
+		'2/1'
+	);
+});
+
+test('format_result renders the tree with pass/fail marks and diff lines', () => {
+	expectSuccess(
+		`
+${importAll}
+${sampleSuite}
+format_result (run_tree suite)`,
+		[
+			'math',
+			'  ✓ adds',
+			'  ✗ breaks',
+			'      expected: 7',
+			'      actual:   8',
+			'  edge',
+			'    ✓ zero',
+		].join('\n')
+	);
+});
+
+test('format_result renders a message-only failure without diff lines', () => {
+	expectSuccess(
+		`
+${importAll}
+t = test_case "boom" (fn _ => fail "it broke");
+format_result (run_tree t)`,
+		['✗ boom', '    it broke'].join('\n')
+	);
+});
+
+test('run_all prints report plus summary and returns counts', () => {
+	const out = execFileSync(
+		'bun',
+		[
+			cli,
+			'-e',
+			`{@test_case, @group, @expect_eq, @run_all} = import "std/test";
+			 run_all [{@path "demo.test.noo", @suite group "math" [
+			   test_case "adds" (fn _ => expect_eq 4 (2 + 2)),
+			   test_case "breaks" (fn _ => expect_eq 7 8)
+			 ]}]`,
+		],
+		{ cwd: repoRoot, encoding: 'utf8', env: { ...process.env, NO_COLOR: '1' } }
+	);
+	expect(out).toContain('demo.test.noo');
+	expect(out).toContain('✓ adds');
+	expect(out).toContain('✗ breaks');
+	expect(out).toContain('1 passed, 1 failed');
+});


### PR DESCRIPTION
## Summary
Phase 3 of docs-wip/TESTING_FRAMEWORK_PLAN.md — the runner core, all plain noolang in `std/test.noo`:
- `TestResult = CaseResult String Expectation | GroupResult String (List TestResult)` — the executed mirror of a `Test` tree.
- `run_tree : Test -> TestResult` — the only effectful step (executes thunks).
- `result_counts`, `format_result` — pure aggregation and report rendering (✓/✗ marks, nested indentation, `expected:`/`actual:` diff lines from the structured Fail payload, message-only fallback).
- `run_all` — prints each suite's report plus `N passed, M failed`, returns the counts; exit codes stay the caller's job (`noo test`, next phase).

## Test plan
- `test/features/std-test-runner.test.ts`: tree-shape mirroring, count aggregation across nesting, exact report rendering (both diff and message-only failures), and a subprocess test of `run_all`'s printed output. Red before implementation.
- Full suite 1250 pass, typecheck clean, doc validation exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TASnoHntaoTfJZpshTGnB