### PR TITLE
CommandFailed carries stdout too (record payload)

### DIFF
--- a/src/evaluator/evaluator.ts
+++ b/src/evaluator/evaluator.ts
@@ -1135,8 +1135,11 @@ export class Evaluator {
 					if (typeof error?.status === 'number') {
 						return createConstructor('Err', [
 							createConstructor('CommandFailed', [
-								createNumber(error.status),
-								createString(String(error.stderr ?? '')),
+								createRecord({
+									code: createNumber(error.status),
+									stdout: createString(String(error.stdout ?? '')),
+									stderr: createString(String(error.stderr ?? '')),
+								}),
 							]),
 						]);
 					}

--- a/stdlib.noo
+++ b/stdlib.noo
@@ -207,13 +207,16 @@ implement Show Result (
 variant ReadError = FileNotFound String | ReadPermissionDenied String | ReadFailed String;
 variant WriteError = WritePermissionDenied String | WriteFailed String;
 
-# Process failure: CommandFailed exitCode stderr (the process ran and exited
-# nonzero) vs ExecFailed message (the process could not run at all)
-variant ExecError = CommandFailed Float String | ExecFailed String;
+# Process failure: CommandFailed (the process ran and exited nonzero — both
+# output streams preserved, a failing process's stdout is still data) vs
+# ExecFailed message (the process could not run at all)
+variant ExecError =
+    CommandFailed {@code Float, @stdout String, @stderr String}
+  | ExecFailed String;
 
 implement Show ExecError (
   show = fn err => match err (
-    CommandFailed code stderr => concat "CommandFailed(" (concat (show code) (concat ", " (concat stderr ")")));
+    CommandFailed info => concat "CommandFailed(" (concat (show (@code info)) (concat ", " (concat (@stderr info) ")")));
     ExecFailed message => concat "ExecFailed(" (concat message ")")
   )
 );

--- a/test/builtins/exec.test.ts
+++ b/test/builtins/exec.test.ts
@@ -35,7 +35,7 @@ describe('exec builtin function', () => {
 			match result (
 				Ok _ => "ok";
 				Err e => match e (
-					CommandFailed code stderr => "ran anyway";
+					CommandFailed _ => "ran anyway";
 					ExecFailed message => message
 				)
 			)

--- a/test/features/exec.test.ts
+++ b/test/features/exec.test.ts
@@ -16,16 +16,29 @@ test('exec success returns Ok stdout', () => {
 	);
 });
 
-test('exec nonzero exit returns Err (CommandFailed code stderr)', () => {
+test('exec nonzero exit returns Err (CommandFailed with code)', () => {
 	expectSuccess(
 		`match (exec "false" []) (
 			Ok _ => -1;
 			Err e => match e (
-				CommandFailed code stderr => code;
+				CommandFailed info => @code info;
 				ExecFailed _ => -2
 			)
 		)`,
 		1
+	);
+});
+
+test('CommandFailed preserves stdout from the failed process', () => {
+	expectSuccess(
+		`match (exec "sh" ["-c", "echo kept-output; exit 3"]) (
+			Ok _ => "ok";
+			Err e => match e (
+				CommandFailed info => @stdout info;
+				ExecFailed _ => "spawn"
+			)
+		)`,
+		expect.stringContaining('kept-output')
 	);
 });
 
@@ -34,7 +47,7 @@ test('exec failure carries stderr text', () => {
 		`match (exec "ls" ["/definitely-no-such-path-xyz"]) (
 			Ok _ => "ok";
 			Err e => match e (
-				CommandFailed code stderr => stderr;
+				CommandFailed info => @stderr info;
 				ExecFailed message => "spawn"
 			)
 		)`,


### PR DESCRIPTION
## Summary
- Designing the test runner's per-file isolation (phase 4) hit this immediately: a failing suite exits nonzero, `exec` returns `CommandFailed`, and the child's stdout — the entire test report — was discarded. A failing process's stdout is still data.
- `CommandFailed`'s payload is now a record: `{@code Float, @stdout String, @stderr String}`. `ExecFailed` unchanged. Breaking change to #136's day-old shape, made while it has exactly one consumer.

## Test plan
- Updated `test/features/exec.test.ts` matches on the record payload; new case proves stdout survives a nonzero exit (`sh -c "echo kept-output; exit 3"`). Red before implementation.
- Full suite 1246 pass, typecheck clean, doc validation exits 0.
- Hand-verified: `code=2 out=out\nerr=err\n` round-trip through both streams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TASnoHntaoTfJZpshTGnB