### PR TITLE
Add noo test: discovery, per-file isolation, exit codes

### DIFF
--- a/docs/tools-and-cli.md
+++ b/docs/tools-and-cli.md
@@ -94,6 +94,39 @@ From [`src/cli.ts:13-29`](../src/cli.ts#L13-L29):
 | `--type-ast-file <file>` | File typed AST | `bun start --type-ast-file demo.noo` |
 | `--symbol-type <file> <symbol>` | Symbol type | `bun start --symbol-type demo.noo myFunc` |
 
+## Testing: `noo test`
+
+`bun start test` discovers every `*.test.noo` under the current directory
+(skipping `node_modules` and `.git`), runs each suite in its own interpreter
+process, prints a report per suite, and exits nonzero if anything failed. The
+process boundary is the isolation mechanism: one crashing suite reports as a
+failure while the rest still run.
+
+A test file imports `std/test` and makes its **last expression** a `Test`
+value (this block is illustrative; test files are discovered and run by
+`noo test`, not imported by docs):
+
+```
+# math.test.noo
+{@test_case, @group, @expect_eq, @expect} = import "std/test";
+
+group "math" [
+  test_case "adds" (fn _ => expect_eq 4 (2 + 2)),
+  test_case "compares" (fn _ => expect "ordering holds" (1 < 2))
+]
+```
+
+Assertions return `Expectation` values — no exceptions, no assertion
+registry: `expect_eq expected actual` (diff on failure, expected first),
+`expect_neq`, `expect label condition` (label is mandatory so failures are
+never mute), `expect_ok` / `expect_err` for `Result`s, `expect_all` (first
+`Fail` wins), and `fail message`. Tests are ordinary values, so table-driven
+tests are just `group "cases" (list_map make_case table)`.
+
+Runner internals (`run_tree`, `format_result`, `result_counts`, `run_all`)
+are exported by `std/test` too — the framework is plain Noolang with no
+interpreter privileges, and its own tests are written in itself.
+
 ## Interactive REPL
 
 Start the REPL with:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -80,6 +80,30 @@ async function main() {
 		return;
 	}
 
+	// `noo test` — run the std/test framework's runner script. The subcommand
+	// is only a trigger: discovery, sub-runs, and exit codes all live in
+	// std/test-runner.noo (public capabilities only). We pass our own path so
+	// the runner can exec child interpreters for per-file isolation.
+	if (args[0] === 'test') {
+		const runnerPath = path.join(__dirname, '..', 'std', 'test-runner.noo');
+		const cliPath = path.join(__dirname, 'cli.ts');
+		const code = fs.readFileSync(runnerPath, 'utf8');
+		const lexer = new Lexer(code);
+		const tokens = lexer.tokenize();
+		const program = parse(tokens);
+		const { program: decoratedProgram, state } = typeAndDecorate(
+			program,
+			undefined,
+			path.dirname(runnerPath)
+		);
+		const evaluator = new Evaluator({
+			traitRegistry: state.traitRegistry,
+			programArgs: [cliPath, ...args.slice(1)],
+		});
+		evaluator.evaluateProgram(decoratedProgram, runnerPath);
+		return;
+	}
+
 	// Check for --tokens flag
 	if (args[0] === '--tokens' && args[1]) {
 		const expr = args[1];

--- a/std/test-runner.noo
+++ b/std/test-runner.noo
@@ -1,0 +1,74 @@
+# noo test — orchestrator for the std/test framework.
+#
+# Plain noolang, run as an entry script by the `noo test` CLI subcommand,
+# which passes the interpreter's cli.ts path as argv[0]. Everything here uses
+# public capabilities only (exec, writeFile, exit) — a userland test runner
+# could do exactly this.
+#
+# Per-file isolation: each *.test.noo runs in its own generated entry process,
+# so one crashing or hanging suite reports as a failed suite while the rest
+# still run. The child's report arrives on stdout either way — a failing
+# process's stdout is still data (CommandFailed carries it).
+
+entry_file = ".noo-test-entry.noo";
+
+# The generated entry: import the suite, run it, exit by failure count.
+# Import specifiers may keep their .noo extension, and the entry lives in the
+# CWD so ./-relative discovery paths resolve as written.
+entry_source = fn file =>
+  "{@run_all} = import \"std/test\";\n"
+  + "suite = import \"" + file + "\";\n"
+  + "result = run_all [{@path \"" + file + "\", @suite suite}];\n"
+  + "{@failed failed} = result;\n"
+  + "exit (if failed > 0 then 1 else 0)";
+
+# Run one suite in a child interpreter; True = suite passed
+run_suite = fn cli file => (
+  _write = writeFile entry_file (entry_source file);
+  outcome = exec "bun" [cli, entry_file];
+  match outcome (
+    Ok output => (_p = print output; True);
+    Err e => match e (
+      CommandFailed info => (
+        _out = print (info | @stdout);
+        _err = print (info | @stderr);
+        False
+      );
+      ExecFailed message => (_p = println (file + ": " + message); False)
+    )
+  )
+);
+
+discover = fn u => (
+  found = exec "find" [
+    ".", "-name", "*.test.noo",
+    "-not", "-path", "*/node_modules/*",
+    "-not", "-path", "*/.git/*"
+  ];
+  match found (
+    Ok output => output | split "\n" | filter (fn line => not (line == ""));
+    Err _ => []
+  )
+);
+
+main = (
+  cli = head argv;
+  match cli (
+    None => (_p = println "noo test: missing interpreter path argument"; exit 2);
+    Some cli_path => (
+      files = discover {};
+      if (length files) == 0
+      then (_p = println "no test files found (*.test.noo)"; exit 0)
+      else (
+        results = list_map (run_suite cli_path) files;
+        _cleanup = exec "rm" ["-f", entry_file];
+        failed = length (filter (fn passed => not passed) results);
+        passed = (length results) - failed;
+        _summary = println ("suites: " + show passed + " passed, " + show failed + " failed");
+        exit (if failed > 0 then 1 else 0)
+      )
+    )
+  )
+);
+
+main

--- a/test/integration/noo-test-subcommand.test.ts
+++ b/test/integration/noo-test-subcommand.test.ts
@@ -1,0 +1,95 @@
+// `noo test`: discovers *.test.noo, runs each suite in its own process
+// (per-file isolation — one crashing file must not kill the run), prints the
+// reports, exits nonzero iff any suite failed.
+import { test, expect } from 'bun:test';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const repoRoot = resolve(import.meta.dir, '..', '..');
+const cli = join(repoRoot, 'src', 'cli.ts');
+
+function makeProject(files: Record<string, string>): string {
+	const dir = mkdtempSync(join(tmpdir(), 'noo-test-cmd-'));
+	for (const [rel, content] of Object.entries(files)) {
+		mkdirSync(join(dir, rel, '..'), { recursive: true });
+		writeFileSync(join(dir, rel), content);
+	}
+	return dir;
+}
+
+function runNooTest(cwd: string): { status: number; out: string } {
+	try {
+		const out = execFileSync('bun', [cli, 'test'], {
+			cwd,
+			encoding: 'utf8',
+			stdio: 'pipe',
+			env: { ...process.env, NO_COLOR: '1' },
+		});
+		return { status: 0, out };
+	} catch (error: any) {
+		return {
+			status: error.status ?? -1,
+			out: String(error.stdout ?? '') + String(error.stderr ?? ''),
+		};
+	}
+}
+
+const passing = `
+{@test_case, @group, @expect_eq} = import "std/test";
+group "math" [
+  test_case "adds" (fn _ => expect_eq 4 (2 + 2))
+]`;
+
+const failing = `
+{@test_case, @group, @expect_eq} = import "std/test";
+group "broken" [
+  test_case "wrong" (fn _ => expect_eq 7 8)
+]`;
+
+const crashing = `
+{@test_case, @group, @expect_eq} = import "std/test";
+boom = unwrap None;
+group "crash" [ test_case "unreachable" (fn _ => expect_eq 1 1) ]`;
+
+test('all suites passing: reports and exits 0', () => {
+	const dir = makeProject({ 'math.test.noo': passing });
+	const { status, out } = runNooTest(dir);
+	expect(out).toContain('✓ adds');
+	expect(status).toBe(0);
+	rmSync(dir, { recursive: true, force: true });
+});
+
+test('a failing suite: diff in output, exit nonzero', () => {
+	const dir = makeProject({
+		'math.test.noo': passing,
+		'sub/broken.test.noo': failing,
+	});
+	const { status, out } = runNooTest(dir);
+	expect(out).toContain('✓ adds');
+	expect(out).toContain('✗ wrong');
+	expect(out).toContain('expected: 7');
+	expect(status).not.toBe(0);
+	rmSync(dir, { recursive: true, force: true });
+});
+
+test('a crashing suite is isolated: other suites still run', () => {
+	const dir = makeProject({
+		'math.test.noo': passing,
+		'crash.test.noo': crashing,
+	});
+	const { status, out } = runNooTest(dir);
+	expect(out).toContain('✓ adds');
+	expect(out).toContain('crash.test.noo');
+	expect(status).not.toBe(0);
+	rmSync(dir, { recursive: true, force: true });
+});
+
+test('no test files found: says so and exits 0', () => {
+	const dir = makeProject({ 'not-a-test.noo': '42' });
+	const { status, out } = runNooTest(dir);
+	expect(out.toLowerCase()).toContain('no test files');
+	expect(status).toBe(0);
+	rmSync(dir, { recursive: true, force: true });
+});


### PR DESCRIPTION
## Summary
Phase 4 — the framework is now end-to-end. `bun start test`:
- discovers `*.test.noo` under the CWD (skips `node_modules`, `.git`)
- generates a per-file entry module (static imports can't name runtime-discovered paths — elm-test's seam) and runs it in a child interpreter
- prints each child's report whether it passed or failed (`CommandFailed` carrying stdout is what #143 was for)
- exits nonzero iff any suite failed; a *crashing* suite is contained by the process boundary and reported while the rest run

The CLI subcommand (`src/cli.ts`) is a thin trigger passing its own path; all logic is `std/test-runner.noo` — plain noolang, public capabilities only (`exec`, `writeFile`, `exit`, `argv`), per the shipped-but-unprivileged principle.

Docs: new "Testing: noo test" section in `docs/tools-and-cli.md`.

## Test plan
- `test/integration/noo-test-subcommand.test.ts` (red before implementation): passing project exits 0 with report; failing suite shows ✗ + diff and exits nonzero; a crashing suite (top-level `unwrap None`) is isolated — the healthy suite still reports; empty project says "no test files" and exits 0.
- Live run output verified by hand (nested groups, diff lines, `suites: 0 passed, 1 failed`, exit 1).
- Full suite 1255 pass, typecheck clean, doc validation exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TASnoHntaoTfJZpshTGnB