### PR TITLE
Unify unit with the empty record and empty tuple

### DIFF
--- a/docs/examples-and-tutorials.md
+++ b/docs/examples-and-tutorials.md
@@ -253,21 +253,21 @@ Type-safe system operations using the `exec` builtin:
 result = exec "echo" ["Hello from Noolang!"];
 match result (
     Ok output => println ("Command output: " + output);
-    Err error => println ("Command failed: " + error)
+    Err error => println ("Command failed: " + show error)
 );
 
 # System information gathering
 hostname_result = exec "hostname" [];
 match hostname_result (
     Ok hostname => println ("Hostname: " + hostname);
-    Err error => println ("Hostname error: " + error)
+    Err error => println ("Hostname error: " + show error)
 );
 
 # Error handling for non-existent commands
 bad_command = exec "this_command_does_not_exist" [];
 match bad_command (
     Ok output => println ("Unexpected success: " + output);
-    Err error => println ("Expected error caught: " + error)
+    Err error => println ("Expected error caught: " + show error)
 );
 ```
 

--- a/docs/language-reference.md
+++ b/docs/language-reference.md
@@ -175,7 +175,7 @@ exec
 result = exec "echo" ["hello world"];
 match result (
     Ok output => println output;    # Prints: hello world
-    Err error => println error      # Handle execution errors
+    Err error => println (show error)   # CommandFailed {@code, @stdout, @stderr} | ExecFailed msg
 )
 ```
 
@@ -186,7 +186,7 @@ match result (
 lsResult = exec "ls" ["-la", "/tmp"];
 match lsResult (
     Ok output => println ("Directory listing:\n" + output);
-    Err error => println ("Failed to list directory: " + error)
+    Err error => println ("Failed to list directory: " + show error)
 )
 ```
 
@@ -198,16 +198,16 @@ getUserInfo = fn _ =>
     match exec "whoami" [] (
         Ok user => match exec "date" [] (
             Ok date => Ok (user + " at " + date);
-            Err error => Err ("Date failed: " + error)
+            Err error => Err ("Date failed: " + show error)
         );
-        Err error => Err ("User lookup failed: " + error)
+        Err error => Err ("User lookup failed: " + show error)
     );
 
 # Use the automation function
 userInfo = getUserInfo {};
 match userInfo (
     Ok info => println ("Current session: " + info);
-    Err error => println ("System info error: " + error)
+    Err error => println ("System info error: " + show error)
 )
 ```
 

--- a/src/typer/__tests__/unit-empty-record.test.ts
+++ b/src/typer/__tests__/unit-empty-record.test.ts
@@ -1,0 +1,45 @@
+// {} is unit, the empty record, and the empty tuple simultaneously — one type,
+// by design (decided 2026-07-17). The three spellings must unify, the value {}
+// infers as that type (not a fresh variable), and the printer's `{}` names a
+// type the annotation parser accepts.
+import { Lexer } from '../../lexer/lexer';
+import { parse } from '../../parser/parser';
+import { typeAndDecorate } from '../index';
+import { typeToString } from '../helpers';
+import { test, expect } from 'bun:test';
+import { parseAndType } from '../../../test/utils';
+
+const typeStr = (code: string) => {
+	const r = parseAndType(code);
+	return typeToString(r.type, r.state.substitution);
+};
+
+const typeChecks = (code: string) =>
+	typeAndDecorate(parse(new Lexer(code).tokenize()));
+
+test('the value {} infers as unit, not a bare type variable', () => {
+	expect(typeStr('{}')).toBe('{}');
+});
+
+test('annotation {} unifies with a unit-returning builtin', () => {
+	expect(typeStr('(fn s => log s) : String -> {} !log')).toBe(
+		'String -> {} !log'
+	);
+});
+
+test('annotation Unit and annotation {} name the same type', () => {
+	expect(typeStr('(fn s => log s) : String -> Unit !log')).toBe(
+		'String -> {} !log'
+	);
+	expect(typeStr('({}) : Unit')).toBe('{}');
+	expect(typeStr('({}) : {}')).toBe('{}');
+});
+
+test('a function returning literal {} accepts a Unit return annotation', () => {
+	expect(typeStr('(fn _ => {}) : Unit -> Unit')).toBe('{} -> {}');
+});
+
+test('non-empty records are unaffected', () => {
+	expect(typeStr('{@a 1}')).toBe('{ @a Float }');
+	expect(() => typeChecks('({@a 1}) : Unit')).toThrow();
+});

--- a/src/typer/builtins.ts
+++ b/src/typer/builtins.ts
@@ -601,12 +601,14 @@ export const initializeBuiltins = (state: TypeState): TypeState => {
 		quantifiedVars: ['record'],
 	});
 	newEnv.set('hasValue', {
+		// `rec` was previously recordType({}) as an "any record" wildcard; the
+		// empty record now IS unit, so the wildcard must be a real variable
 		type: createBinaryFunctionType(
-			recordType({}),
+			typeVariable('rec'),
 			typeVariable('a'),
 			boolType()
 		),
-		quantifiedVars: ['a'],
+		quantifiedVars: ['rec', 'a'],
 	});
 	//FIXME this needs to apply the constraint correctly
 	newEnv.set('set', {
@@ -614,11 +616,11 @@ export const initializeBuiltins = (state: TypeState): TypeState => {
 			[
 				typeVariable('accessor'), // Accept any accessor function type
 				typeVariable('a'),
-				recordType({}),
+				typeVariable('rec'),
 			],
-			recordType({})
+			typeVariable('rec')
 		),
-		quantifiedVars: ['accessor', 'a'],
+		quantifiedVars: ['accessor', 'a', 'rec'],
 	});
 
 	// Tuple operations - only keep sound ones

--- a/src/typer/expression-dispatcher.ts
+++ b/src/typer/expression-dispatcher.ts
@@ -1,5 +1,5 @@
 // Type expression dispatcher with proper error handling
-import { type Expression, typeVariable } from '../ast';
+import { type Expression, unitType } from '../ast';
 import { TypeState, TypeResult, createPureTypeResult } from './types';
 import {
 	typeLiteral,
@@ -82,9 +82,9 @@ export const typeExpression = (
 			return typeImport(expr, state);
 
 		case 'unit':
-			// {} should be polymorphic - it can unify with unit, empty tuples, and empty records
-			// Use a type variable that can unify with any of these types
-			return createPureTypeResult(typeVariable('empty_braces'), state);
+			// {} IS unit — and unit, the empty record, and the empty tuple are one
+			// type (normalized in unify), so no polymorphism is needed here
+			return createPureTypeResult(unitType(), state);
 
 		case 'type-definition':
 			return typeTypeDefinition(expr, state);

--- a/src/typer/helpers.ts
+++ b/src/typer/helpers.ts
@@ -498,7 +498,8 @@ export const typeToString = (
 				const fields = Object.entries(t.fields)
 					.map(([name, fieldType]) => `@${name} ${norm(fieldType)}`)
 					.join(', ');
-				return fields.length > 0 ? `{ ${fields} }` : `{ }`;
+				// The empty record IS unit — print the one spelling for the one type
+				return fields.length > 0 ? `{ ${fields} }` : `{}`;
 			}
 			case 'union':
 				return `(${t.types.map(norm).join(' | ')})`;

--- a/src/typer/unify.ts
+++ b/src/typer/unify.ts
@@ -68,8 +68,17 @@ const unifyInternal = (
 	// Early equality check before substitution for performance
 	if (t1 === t2) return state;
 
-	const s1 = substitute(t1, state.substitution);
-	const s2 = substitute(t2, state.substitution);
+	// {} is unit, the empty record, and the empty tuple simultaneously — one
+	// type by design. Normalize the degenerate spellings to unit so they unify.
+	const normalizeUnit = (t: Type): Type => {
+		if (t.kind === 'record' && Object.keys(t.fields).length === 0)
+			return { kind: 'unit' };
+		if (t.kind === 'tuple' && t.elements.length === 0) return { kind: 'unit' };
+		return t;
+	};
+
+	const s1 = normalizeUnit(substitute(t1, state.substitution));
+	const s2 = normalizeUnit(substitute(t2, state.substitution));
 
 	if (typesEqual(s1, s2)) return state;
 

--- a/test/features/exit.test.ts
+++ b/test/features/exit.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from 'node:child_process';
 import { join, resolve } from 'node:path';
 import { runCode } from '../utils';
 
-const repoRoot = resolve(import.meta.dir, '..', '..');
+const repoRoot = resolve(__dirname, '..', '..');
 const cli = join(repoRoot, 'src', 'cli.ts');
 
 test('exit has type Float -> {} with an effect', () => {

--- a/test/features/std-test-runner.test.ts
+++ b/test/features/std-test-runner.test.ts
@@ -6,7 +6,7 @@ import { execFileSync } from 'node:child_process';
 import { join, resolve } from 'node:path';
 import { expectSuccess } from '../utils';
 
-const repoRoot = resolve(import.meta.dir, '..', '..');
+const repoRoot = resolve(__dirname, '..', '..');
 const cli = join(repoRoot, 'src', 'cli.ts');
 
 const importAll = `{@test_case, @group, @expect_eq, @fail, @run_tree, @format_result, @result_counts, @run_all} = import "std/test";`;

--- a/test/integration/entry-file-relative-import.test.ts
+++ b/test/integration/entry-file-relative-import.test.ts
@@ -7,7 +7,7 @@ import { execFileSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 
-const repoRoot = resolve(import.meta.dir, '..', '..');
+const repoRoot = resolve(__dirname, '..', '..');
 const cli = join(repoRoot, 'src', 'cli.ts');
 
 const dir = mkdtempSync(join(tmpdir(), 'noo-entry-import-'));

--- a/test/integration/noo-test-subcommand.test.ts
+++ b/test/integration/noo-test-subcommand.test.ts
@@ -7,7 +7,7 @@ import { execFileSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 
-const repoRoot = resolve(import.meta.dir, '..', '..');
+const repoRoot = resolve(__dirname, '..', '..');
 const cli = join(repoRoot, 'src', 'cli.ts');
 
 function makeProject(files: Record<string, string>): string {


### PR DESCRIPTION
## Summary
Decision from today's design discussion: `{}` is unit, the empty record, and the empty tuple **as one type**, not three types sharing a value.

Before: the value `{}` inferred as a fresh type variable; the unit type printed as `{}` while that spelling in annotation position parsed as empty record and failed to unify with unit (`Expected: unit, Got: { }`) — so the printer taught an annotation that didn't typecheck, and the honest signature for `std/test-runner.noo`'s `main` was unwritable in its natural spelling.

Now:
- `unify` normalizes zero-field records and zero-element tuples to unit
- the value `{}` infers as unit directly (the `empty_braces` placeholder variable is gone)
- the printer renders the empty record as `{}` — one type, one spelling; `Unit` remains as the named equivalent

Fallout: `hasValue` and `set` used `recordType({})` as an "any record" wildcard — worked only because empty records unified wide. Replaced with honest type variables (same permissiveness as before; `set`'s pre-existing FIXME about its result type is untouched and still tracked).

## Test plan
- New `src/typer/__tests__/unit-empty-record.test.ts` (red before): value inference, `: {}` against a unit builtin, `Unit` ≡ `{}`, literal-`{}` bodies under `Unit` annotations, non-empty records unaffected (`: Unit` on `{@a 1}` still rejected).
- Full suite 1260 pass, typecheck clean, doc validation exits 0.
- Hand-verified per hazard note: `--types '{}'` ⇒ `{}`; `exit` ⇒ `Float -> {} !ffi`; `set @age 42 {@name "A"}` evaluates unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TASnoHntaoTfJZpshTGnB