### PR TITLE
Run CI on every PR: paths filter conflicts with required checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,25 +21,11 @@ on:
       - 'package.json'
       - 'tsconfig*.json'
       - '.github/workflows/ci.yml'
+  # No paths filter on pull_request: required status checks block merging
+  # until they report, so a PR that skips the workflow would be unmergeable.
   pull_request:
     branches: 
       - main
-    paths:
-      - 'src/**'
-      - 'test/**'
-      - 'scripts/**'
-      - 'benchmarks/**'
-      - 'lsp/**'
-      - 'examples/**'
-      - 'docs/**'
-      - 'std/**'
-      - '*.noo'
-      - 'noolang.json'
-      - 'validate_examples.js'
-      - 'README.md'
-      - 'package.json'
-      - 'tsconfig*.json'
-      - '.github/workflows/ci.yml'
   workflow_dispatch:  # Allow manual triggering
 
 jobs:


### PR DESCRIPTION
## Summary
Follow-up to making `typescript-check`/`core-tests`/`documentation-validation` required on `main`: with a `pull_request` paths filter, a PR touching only unlisted files (docs-wip, .gitignore, …) never starts the workflow — required checks never report and the merge is blocked forever. Removed the filter from the `pull_request` trigger only; `push` keeps its filter.

## Test plan
- This PR runs the full workflow; required checks report and gate as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TASnoHntaoTfJZpshTGnB