### PR TITLE
Relax sequence grammar: unit-typed bare items and `_ =` wildcard discard

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ addNums = fn x y => x + y : Float -> Float -> Float;
 double = fn x => x * 2 : Float -> Float;
 
 # Complex type annotations with effects
-logger = fn msg => print msg : String -> String !write;
+logger = fn msg => print msg : String -> {} !write;
 readConfig = fn path => readFile path : String -> Result String ReadError !read;
 ```
 
@@ -963,8 +963,8 @@ Noolang provides a set of built-in functions organized by category:
 - **`tupleIsEmpty`** - Check if tuple is empty: `Tuple -> Bool`
 
 #### I/O Operations (Effectful)
-- **`print`** - Print value: `a -> a` (effect: `!write`)
-- **`println`** - Print line: `a -> a` (effect: `!write`)
+- **`print`** - Print value: `a -> {}` (effect: `!write`)
+- **`println`** - Print line: `a -> {}` (effect: `!write`)
 - **`readFile`** - Read file: `String -> String` (effect: `!read`)
 - **`writeFile`** - Write file: `String -> String -> Unit` (effect: `!write`)
 - **`log`** - Log message: `String -> Unit` (effect: `!log`)
@@ -1043,7 +1043,7 @@ sumTwo = fn x y => x + y : Float -> Float -> Float;
 readAndPrint = fn filename => (
   content = readFile filename;
   match content ( Ok text => print text; Err e => print (show e) )
-) : String -> String !read !write;
+) : String -> {} !read !write;
 
 # System operations with FFI effects
 runCommand = fn cmd args => exec cmd args : String -> List String -> Result String ExecError !ffi;

--- a/docs/language-reference.md
+++ b/docs/language-reference.md
@@ -434,6 +434,35 @@ z = 9;
 calculation = (base = x * 2; helper = 3; base + helper);
 ```
 
+Inside a parenthesized sequence, a non-final item may also be a **bare
+expression**, but only if its type is `{}` (unit) — dropping unit discards
+nothing, while silently dropping data is almost always a lost result. Effects
+of bare items propagate exactly as bindings' do:
+
+```noolang
+# println returns {}, so no throwaway binding is needed
+greet = fn name => (println ("hello " + name); name);
+```
+
+To discard a non-unit value deliberately, bind it to the wildcard `_`, which
+evaluates the right-hand side and binds nothing:
+
+```noolang
+# writeFile returns Result {} WriteError; `_ =` discards it explicitly
+touch = fn path => (_ = writeFile path ""; path);
+```
+
+The following would be a type error (a non-unit value is silently dropped —
+this also catches dead code like a mistyped accumulation line):
+
+```
+# TypeError: Cannot unify types in discarding a non-final sequence item
+f = fn x => (x + 1; x)
+```
+
+The top level of a program is exempt: unparenthesized top-level sequences may
+display values of any type, as this reference itself does throughout.
+
 ### Record Operations
 
 ```noolang

--- a/docs/type-system.md
+++ b/docs/type-system.md
@@ -208,7 +208,7 @@ effects**:
 
 ```noolang
 # Over-declaring is allowed — annotation adds !read even though body only writes
-verbose = fn x => print x : String -> String !write !read;
+verbose = fn x => print x : String -> {} !write !read;
 verbose "ok"
 ```
 
@@ -216,7 +216,7 @@ The following would be a type error (annotation omits `!write`):
 
 ```
 # TypeError: Type annotation omits effect !write performed by the expression
-bad = fn x => print x : String -> String;
+bad = fn x => print x : String -> {};
 ```
 
 ## Type System Integration

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -261,6 +261,11 @@ export interface BinaryExpression {
 		| '||';
 	left: Expression;
 	right: Expression;
+	// Set on `;`-sequences built inside parentheses. Nested sequences only
+	// arise via parens, so this marks the scope where the typer requires
+	// non-final bare expressions to be unit-typed; the program's top-level
+	// sequence stays permissive for script/literate-doc display style.
+	parenthesized?: boolean;
 	type?: Type;
 	location: Location;
 }

--- a/src/evaluator/__tests__/evaluator.test.ts
+++ b/src/evaluator/__tests__/evaluator.test.ts
@@ -310,7 +310,7 @@ describe('Evaluator', () => {
 	});
 
 	test('definition with sequence on right side using parentheses', () => {
-		const result = runCode('foo = (1; 2); foo');
+		const result = runCode('foo = (_ = 1; 2); foo');
 		expect(result.finalValue).toBe(2);
 	});
 

--- a/src/evaluator/evaluator.ts
+++ b/src/evaluator/evaluator.ts
@@ -1001,7 +1001,7 @@ export class Evaluator {
 			'println',
 			createNativeFunction('println', (value: Value) => {
 				console.log(isString(value) ? value.value : valueToString(value));
-				return value;
+				return createUnit();
 			})
 		);
 

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -293,7 +293,10 @@ const parseParenExpr: C.Parser<Expression> = tokens => {
 			C.lazy(() => parseSequence), // Use parseSequence to allow full semicolon-separated sequences
 			C.punctuation(')')
 		),
-		([_open, expr, _close]) => expr
+		([_open, expr, _close]) =>
+			expr.kind === 'binary' && expr.operator === ';'
+				? { ...expr, parenthesized: true }
+				: expr
 	)(tokens);
 };
 
@@ -1163,7 +1166,29 @@ export const parseRecordDestructuring: C.Parser<
 };
 
 // --- Combined Definition Parser (handles regular definitions and destructuring) ---
+// --- Wildcard Binding ---
+// `_ = expr` evaluates expr and binds nothing: the explicit way to discard a
+// non-unit value in sequence position (bare expressions must be unit-typed).
+// Represented as a definition named `_`; the lexer emits bare `_` as
+// punctuation, so no variable expression can ever read the binding back.
+const parseWildcardBinding: C.Parser<DefinitionExpression> = C.map(
+	C.seq(
+		C.punctuation('_'),
+		C.operator('='),
+		C.lazy(() => parseSequenceTerm)
+	),
+	([underscore, _equals, value]): DefinitionExpression => ({
+		kind: 'definition',
+		name: '_',
+		value,
+		location: underscore.location,
+	})
+);
+
 const parseDefinition: C.Parser<Expression> = tokens => {
+	const wildcardResult = parseWildcardBinding(tokens);
+	if (wildcardResult.success) return wildcardResult;
+
 	// First try destructuring patterns
 	if (isDestructuringPattern(tokens)) {
 		return C.choice2<Expression>(
@@ -1287,6 +1312,9 @@ const parseWhereDefinition: C.Parser<
 	| RecordDestructuringExpression
 	| MutableDefinitionExpression
 > = tokens => {
+	const wildcardResult = parseWildcardBinding(tokens);
+	if (wildcardResult.success) return wildcardResult;
+
 	// Try mutable definition first
 	const mutableResult = parseMutableDefinition(tokens);
 	if (mutableResult.success) {

--- a/src/typer/__tests__/effect-inference.test.ts
+++ b/src/typer/__tests__/effect-inference.test.ts
@@ -15,7 +15,7 @@ const typeChecks = (code: string) => typeAndDecorate(parse(new Lexer(code).token
 // --- Effect inference: a function's body effects are latent on its type ---
 
 test('Effect inference - fn x => print x carries !write on its type', () => {
-	expect(typeStr('fn x => print x')).toBe('a -> a !write');
+	expect(typeStr('fn x => print x')).toBe('a -> {} !write');
 });
 
 test('Effect inference - a pure function has no effect', () => {
@@ -29,7 +29,7 @@ test('Effect inference - readFile body surfaces !read', () => {
 });
 
 test('Effect inference - effects propagate through a wrapping call', () => {
-	expect(typeStr('g = fn x => print x; fn y => g y')).toBe('a -> a !write');
+	expect(typeStr('g = fn x => print x; fn y => g y')).toBe('a -> {} !write');
 });
 
 // --- Effect enforcement: annotations may over-declare but not omit effects ---
@@ -42,12 +42,12 @@ test('Effect enforcement - annotation omitting a performed effect is rejected', 
 
 test('Effect enforcement - annotation omitting one of several effects is rejected', () => {
 	expect(() =>
-		typeChecks('fn n => (log "x"; print n) : Float -> Float !write')
+		typeChecks('fn n => (log "x"; print n) : Float -> {} !write')
 	).toThrow(/omits effect .*log/);
 });
 
 test('Effect enforcement - a matching effect annotation is accepted', () => {
-	expect(typeStr('fn x => print x : a -> a !write')).toBe('a -> a !write');
+	expect(typeStr('fn x => print x : a -> {} !write')).toBe('a -> {} !write');
 });
 
 test('Effect enforcement - over-declaring effects (conservative) is allowed', () => {

--- a/src/typer/builtins.ts
+++ b/src/typer/builtins.ts
@@ -198,22 +198,16 @@ export const initializeBuiltins = (state: TypeState): TypeState => {
 		quantifiedVars: ['a', 'b'],
 	});
 
-	// Effectful functions - I/O and logging
+	// Effectful functions - I/O and logging. Both return unit (which is what
+	// the print native always did), so a bare `println ...` mid-sequence
+	// satisfies the unit-discard rule.
 	newEnv.set('print', {
-		type: functionType(
-			[typeVariable('a')],
-			typeVariable('a'),
-			new Set(['write'])
-		),
+		type: functionType([typeVariable('a')], unitType(), new Set(['write'])),
 		quantifiedVars: ['a'],
 	});
 
 	newEnv.set('println', {
-		type: functionType(
-			[typeVariable('a')],
-			typeVariable('a'),
-			new Set(['write'])
-		),
+		type: functionType([typeVariable('a')], unitType(), new Set(['write'])),
 		quantifiedVars: ['a'],
 	});
 

--- a/src/typer/type-inference.ts
+++ b/src/typer/type-inference.ts
@@ -998,6 +998,23 @@ const handleSafeThrush = (
 	}
 };
 
+// Statement forms whose point is the binding they introduce, not the value
+// they produce — exempt from the unit-discard check on sequence items.
+const bindingStatementKinds = new Set<Expression['kind']>([
+	'definition',
+	'mutable-definition',
+	'mutation',
+	'tuple-destructuring',
+	'record-destructuring',
+	'type-definition',
+	'user-defined-type',
+	'constraint-definition',
+	'implement-definition',
+]);
+
+const isBindingStatement = (statement: Expression): boolean =>
+	bindingStatementKinds.has(statement.kind);
+
 export const typeBinary = (
 	expr: BinaryExpression,
 	state: TypeState
@@ -1006,6 +1023,7 @@ export const typeBinary = (
 	if (expr.operator === ';') {
 		// Flatten the semicolon sequence and process each statement exactly once
 		const statements = flattenStatements(expr);
+		const finalStatement = statements[statements.length - 1];
 		let currentState = state;
 		let finalType = null;
 		let allEffects = emptyEffects();
@@ -1015,6 +1033,28 @@ export const typeBinary = (
 			currentState = result.state;
 			finalType = result.type;
 			allEffects = unionEffects(allEffects, result.effects);
+
+			// In a nested (parenthesized) sequence a non-final bare expression's
+			// value is silently discarded, so it must be unit — dropping {} drops
+			// nothing, while a dropped non-unit value is usually a lost result.
+			// The top-level program sequence stays permissive (script style).
+			if (
+				expr.parenthesized &&
+				statement !== finalStatement &&
+				!isBindingStatement(statement)
+			) {
+				currentState = unify(
+					result.type,
+					unitType(),
+					currentState,
+					getExprLocation(statement),
+					{
+						reason: 'sequence_discard',
+						operation: 'discarding a non-final sequence item',
+						hint: 'A bare expression before a `;` is evaluated and its value discarded, so it must have type {}. Bind the value with a name, or write `_ = ...` to discard it deliberately.',
+					}
+				);
+			}
 		}
 
 		return createTypeResult(finalType || unitType(), allEffects, currentState);

--- a/src/typer/type-operations.ts
+++ b/src/typer/type-operations.ts
@@ -391,13 +391,24 @@ export const freshenRecordStructure = (
 	return [{ fields: newFields }, currentState];
 };
 
-// Helper to flatten semicolon-separated binary expressions into individual statements
+// Helper to flatten semicolon-separated binary expressions into individual
+// statements. Parenthesized sub-sequences stay whole: they are their own
+// discard scope (typeBinary unit-checks their non-final bare items), so
+// flattening them into the parent would misattribute that check.
 export const flattenStatements = (expr: Expression): Expression[] => {
 	if (expr.kind === 'binary' && expr.operator === ';') {
-		return [...flattenStatements(expr.left), ...flattenStatements(expr.right)];
+		return [
+			...flattenSequenceChild(expr.left),
+			...flattenSequenceChild(expr.right),
+		];
 	}
 	return [expr];
 };
+
+const flattenSequenceChild = (expr: Expression): Expression[] =>
+	expr.kind === 'binary' && expr.operator === ';' && expr.parenthesized
+		? [expr]
+		: flattenStatements(expr);
 
 // Load standard library from stdlib.noo
 export const loadStdlib = (state: TypeState): TypeState => {

--- a/std/test-runner.noo
+++ b/std/test-runner.noo
@@ -24,17 +24,19 @@ entry_source = fn file =>
 
 # Run one suite in a child interpreter; True = suite passed
 run_suite = fn cli file => (
-  _write = writeFile entry_file (entry_source file);
+  # Deliberate discard: a failed write surfaces as the child process failing
+  # to find its entry file, which already reports the suite as failed
+  _ = writeFile entry_file (entry_source file);
   outcome = exec "bun" [cli, entry_file];
   match outcome (
-    Ok output => (_p = print output; True);
+    Ok output => (print output; True);
     Err e => match e (
       CommandFailed info => (
-        _out = print (info | @stdout);
-        _err = print (info | @stderr);
+        print (info | @stdout);
+        print (info | @stderr);
         False
       );
-      ExecFailed message => (_p = println (file + ": " + message); False)
+      ExecFailed message => (println (file + ": " + message); False)
     )
   )
 );
@@ -54,17 +56,17 @@ discover = fn u => (
 main = (fn _ => (
   cli = head argv;
   match cli (
-    None => (_p = println "noo test: missing interpreter path argument"; exit 2);
+    None => (println "noo test: missing interpreter path argument"; exit 2);
     Some cli_path => (
       files = discover {};
       if (length files) == 0
-      then (_p = println "no test files found (*.test.noo)"; exit 0)
+      then (println "no test files found (*.test.noo)"; exit 0)
       else (
         results = list_map (run_suite cli_path) files;
-        _cleanup = exec "rm" ["-f", entry_file];
+        _ = exec "rm" ["-f", entry_file];
         failed = length (filter (fn passed => not passed) results);
         passed = (length results) - failed;
-        _summary = println ("suites: " + show passed + " passed, " + show failed + " failed");
+        println ("suites: " + show passed + " passed, " + show failed + " failed");
         exit (if failed > 0 then 1 else 0)
       )
     )

--- a/std/test.noo
+++ b/std/test.noo
@@ -127,14 +127,14 @@ run_all = fn suites => (
   totals = reduce
     (fn acc entry => (
       result = entry | @suite | run_tree;
-      _p1 = entry | @path | println;
-      _p2 = result | format_result | println;
+      entry | @path | println;
+      result | format_result | println;
       add_counts acc (result_counts result)
     ))
     no_counts
     suites;
   {@passed passed, @failed failed} = totals;
-  _summary = println (show passed + " passed, " + show failed + " failed");
+  println (show passed + " passed, " + show failed + " failed");
   totals
 );
 

--- a/test/features/effects/effects_phase3.test.ts
+++ b/test/features/effects/effects_phase3.test.ts
@@ -173,7 +173,7 @@ test('Effects Phase 3 - Effect Propagation in Control Flow - conditionals merge 
 	expectEffects(
 		`
 				x = 5;
-				if x > 0 then (print x; {}) else (random; {})
+				if x > 0 then (print x; {}) else (_ = random; {})
 			`,
 		['rand', 'write']
 	);
@@ -184,7 +184,7 @@ test('Effects Phase 3 - Effect Propagation in Control Flow - nested conditionals
 		`
 				x = 5;
 				if x > 0 then (
-					if x > 10 then (readFile "big.txt"; {}) else (print x; {})
+					if x > 10 then (_ = readFile "big.txt"; {}) else (print x; {})
 				) else (log "negative"; {})
 			`,
 		['log', 'read', 'write']
@@ -209,7 +209,7 @@ test('Effects Phase 3 - Effect Propagation in Pattern Matching - pattern matchin
 		`
 				result = Ok 42;
 				match result (
-					Ok value => print value;
+					Ok value => (print value; 0);
 					Err msg => (log msg; random)
 				)
 			`,

--- a/test/language-features/sequence-discard.test.ts
+++ b/test/language-features/sequence-discard.test.ts
@@ -1,0 +1,87 @@
+// Sequence-position discard rules:
+// - A non-final bare expression in a *nested* (parenthesized) sequence must be
+//   unit-typed; its effects propagate like a binding's. Dropping unit discards
+//   nothing; silently dropping data is the bug this rule catches.
+// - `_ = expr` is the explicit escape valve: binds nothing, accepts any type.
+// - The unparenthesized top level of a program stays permissive — literate
+//   docs and scripts display values there by convention.
+import { test, expect, describe } from 'bun:test';
+import { expectSuccess, expectError, runCode } from '../utils';
+
+describe('bare expressions in nested sequences', () => {
+	test('unit-typed bare expression is allowed mid-sequence', () => {
+		expectSuccess('f = fn x => (println "hi"; x + 1); f 1', 2);
+	});
+
+	test('bare log call is allowed mid-sequence', () => {
+		expectSuccess('f = fn x => (log "hi"; x + 1); f 1', 2);
+	});
+
+	test('effects of a bare item propagate to the enclosing function', () => {
+		const result = runCode('fn x => (println "hi"; x + 1)');
+		expect(result.finalType).toContain('!write');
+	});
+
+	test('non-unit bare expression mid-sequence is a type error', () => {
+		expectError('f = fn x => (1 + 1; x); f 2', /unit|discard/);
+	});
+
+	test('non-unit bare expression in a parenthesized sequence is a type error', () => {
+		expectError('(1 + 1; 2)', /unit|discard/);
+	});
+
+	test('Result-returning call may not be bare (silent failure drop)', () => {
+		expectError('f = fn p => (writeFile p "x"; 1); f "/tmp/x"', /unit|discard/);
+	});
+
+	test('the final item of a sequence is unrestricted', () => {
+		expectSuccess('(println "a"; 42)', 42);
+	});
+
+	test('a nested unit-typed paren sequence is fine as a non-final item', () => {
+		expectSuccess('f = fn x => ((println "a"; {}); x); f 7', 7);
+	});
+
+	test('non-unit deep inside a nested paren sequence still errors', () => {
+		expectError('f = fn x => ((println "a"; [1]); x); f 7', /unit|discard/);
+	});
+
+	test('named bindings of non-unit values are still fine mid-sequence', () => {
+		expectSuccess('f = fn x => (a = [1, 2]; length a + x); f 1', 3);
+	});
+
+	test('top-level unparenthesized sequences stay permissive', () => {
+		expectSuccess('1 + 1; "x"', 'x');
+	});
+});
+
+describe('_ = expr wildcard binding', () => {
+	test('accepts a non-unit value silently', () => {
+		expectSuccess('f = fn x => (_ = [1, 2, 3]; x); f 5', 5);
+	});
+
+	test('works at the top level', () => {
+		expectSuccess('_ = 42; "done"', 'done');
+	});
+
+	test('evaluates its right-hand side', () => {
+		expectSuccess('mut n = 0; f = fn u => (_ = mut! n = 9; n); f {}', 9);
+	});
+
+	test('propagates effects', () => {
+		const result = runCode('fn x => (_ = println "hi"; x)');
+		expect(result.finalType).toContain('!write');
+	});
+
+	test('does not bind a referenceable name', () => {
+		expectError('_ = 5; _ + 1');
+	});
+
+	test('may repeat within one sequence', () => {
+		expectSuccess('f = fn x => (_ = [1]; _ = "s"; x); f 3', 3);
+	});
+
+	test('is accepted in where clauses', () => {
+		expectSuccess('y where (_ = println "side"; y = 2)', 2);
+	});
+});


### PR DESCRIPTION
## What

Kills the `_p1 = println ...` discard-binding boilerplate in two pieces:

1. **Bare expressions in sequence position, unit-typed only.** A non-final item in a parenthesized sequence may be a bare expression; the typer unifies its type with `{}` and propagates its effects exactly as bindings' are. The parser already accepted bare items — but silently dropped values of *any* type. Now `(compute x; rest)` where `compute x : Float` is a type error.

2. **`_ = expr` wildcard binding.** Evaluates the RHS, binds nothing, accepts any type — the explicit escape valve for deliberate non-unit discard. Also accepted in `where` clauses. Bare `_` stays unreferenceable (the lexer emits it as punctuation), so nothing can read the "binding" back.

## What the unit restriction rejects, and why

A non-final bare expression whose type is not `{}` is a type error. Silently dropping *data* is the bug class expression languages invite — a typo'd accumulation line (`acc + x;` where you meant `acc = acc + x;`) just vanishes. Dropping `{}` discards nothing, so effectful unit-returning calls (`println`, `log`) sequence naturally. Side benefit: a bare pure expression like `1 + 1` mid-sequence is now caught as dead code. `writeFile`/`exec` return `Result`, so their bare form is rejected — that's the rule working; the old `_write = writeFile ...` in std/test-runner.noo was silently ignoring write failures, and the new `_ = writeFile ...` at least says so out loud (with a comment on why the discard is sound there).

## Deviations from the brief

- **The brief's parser claim was stale**: sequences already accepted bare non-binding items and silently dropped their values, top to bottom. The work was the typer check + the `_` binding, not a grammar relaxation.
- **Scope: the rule applies to parenthesized sequences only; the program's top-level sequence stays permissive.** Docs validate as concatenated literate programs whose blocks display non-unit values on nearly every line (`42;`, `at 0 [10, 20, 30];` — hundreds of sites). Enforcing at top level either breaks all documentation or forces the same throwaway-binding tax onto docs that this feature exists to remove. Nested sequences (where the fn-body boilerplate actually lives) only arise via parens, so "parenthesized = enforced" is exactly the nested scope. Consequence: `bun src/cli.ts -e '(1 + 1; 2)'` errors, `-e '1 + 1; 2'` doesn't.
- **`print`/`println` retyped from `a -> a !write` to `a -> {} !write`.** Under the unit rule a pass-through `println` can't be bare, defeating the feature's main use. The `print` native already returned unit — its type lied — and no code anywhere consumed the pass-through value. `println`'s native now returns unit too.

## Sweep

- std/test.noo, std/test-runner.noo: all `_p1`/`_p2`/`_write`/`_out`/`_err`/`_cleanup`/`_summary` fake bindings replaced with bare calls or `_ =`. stdlib.noo had none.
- Existing tests asserting `print : a -> a` or exploiting silent drop (`foo = (1; 2)`, `(random; {})`) updated to the new semantics.
- docs/language-reference.md documents the rule (validated examples); README/type-system.md print types corrected.

## Verification

- `AGENT=1 bun test`: 1270 pass / 0 fail. New suite: test/language-features/sequence-discard.test.ts (18 tests, written red-first).
- `bun run typecheck`, `node validate_examples.js`: clean.
- Hand probes per the typer hazard: `fn x => (println "hi"; x + 1)` : `Float -> Float !write`; `fn x => (_ = writeFile "f" "c"; x)` : `a -> a !write`; `println` : `a -> {} !write`.
- std runner exercised end-to-end (`noo test` against a scratch suite: pass/fail report and summary intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TASnoHntaoTfJZpshTGnB