### PR TITLE
Reject unit-returning effects in template holes instead of Show Unit

### DIFF
--- a/src/evaluator/evaluator.ts
+++ b/src/evaluator/evaluator.ts
@@ -2902,7 +2902,6 @@ export class Evaluator {
 		if (isList(value)) return 'List';
 		if (isRecord(value)) return 'Record';
 		if (isTuple(value)) return 'Tuple';
-		if (isUnit(value)) return 'Unit';
 		if (isConstructor(value)) {
 			// Resolve the constructor to its variant type; fall back to the
 			// constructor name for values whose definition this evaluator never

--- a/stdlib.noo
+++ b/stdlib.noo
@@ -63,10 +63,6 @@ implement Show String (
   show = fn s => s
 );
 
-implement Show Unit (
-  show = fn _ => "{}"
-);
-
 # Add trait implementations for built-in types
 implement Add Float (
   add = primitive_float_add

--- a/test/template-strings.test.ts
+++ b/test/template-strings.test.ts
@@ -152,7 +152,7 @@ describe('template strings — end to end', () => {
 	});
 
 	test('effects performed in a hole propagate to the template', () => {
-		const result = parseAndType('`said: ${print "hi"}`');
+		const result = parseAndType('`said: ${(print "hi"; 42)}`');
 		const typeStr = typeToString(result.type!, result.state.substitution);
 		expect(typeStr).toContain('String');
 		expect(Array.from(result.effects ?? [])).toContain('write');
@@ -162,6 +162,13 @@ describe('template strings — end to end', () => {
 		expectError(
 			'variant Secret = Hidden; `${Hidden}`',
 			/no implementation of trait function 'show' for Secret/i
+		);
+	});
+
+	test('a hole that performs an effect but yields Unit is a type error, not a silent {}', () => {
+		expectError(
+			'`said: ${print "hi"}`',
+			/no implementation of trait function 'show' for unit/i
 		);
 	});
 


### PR DESCRIPTION
## What

Follow-up to #151 (supersedes #152, which had merge conflicts from #151's squash-merge history). That PR merged with a `Show Unit` implementation added to fix a CI failure (`${print "hi"}` desugars to `show (print "hi")`, and `print` returns `Unit`, which had no `Show` impl).

On reflection, `Show Unit` isn't the right fix: a hole that performs an effect purely for its side effect (`${print "hi"}`) shouldn't silently interpolate `"{}"` into the string — it should be a type error, same as any other Show-less type in a hole. This also matches the contract already documented in `docs/language-reference.md`: "A hole whose type has no `Show` implementation is a type error."

## Changes

- Revert `implement Show Unit` in `stdlib.noo`.
- Revert the `getValueTypeName` unit-dispatch addition in `src/evaluator/evaluator.ts` (no longer needed without a `Show Unit` impl to dispatch to).
- `test/template-strings.test.ts`:
  - The effect-propagation test now uses a hole that performs an effect *and* yields a Show-able value (`` `said: ${(print "hi"; 42)}` ``) instead of a bare `${print "hi"}`.
  - Added a test asserting a hole that performs an effect but yields `Unit` is a type error (`no implementation of trait function 'show' for unit`), not a silent `{}`.

## Verification

- Full suite: 1291 pass / 0 fail.
- `node validate_examples.js`: clean (no doc changes needed — the stricter behavior already matches the documented contract).


---
_Generated by [Claude Code](https://claude.ai/code/session_01AG2p7ChoDB6t1DGAaGTVTV)_