### PR TITLE
Fix effects dropped when a trait function's argument type is still deferred

### DIFF
--- a/src/typer/function-application.ts
+++ b/src/typer/function-application.ts
@@ -50,7 +50,7 @@ export const typeApplication = (
 			funcType,
 			argTypes,
 			currentState,
-			funcResult
+			allEffects
 		);
 		if (traitResult) {
 			return traitResult;

--- a/src/typer/trait-function-handling.ts
+++ b/src/typer/trait-function-handling.ts
@@ -3,6 +3,7 @@ import {
 	type Type,
 	type Constraint,
 	type FunctionType,
+	type Effect,
 } from '../ast';
 import { throwTypeError, typeToString } from './helpers';
 import {
@@ -29,7 +30,7 @@ export function handleTraitFunctionApplication(
 	funcType: Type,
 	argTypes: Type[],
 	currentState: TypeState,
-	funcResult: TypeResult
+	allEffects: Set<Effect>
 ): TypeResult | null {
 	// Check if this could be a trait function call
 	// Only call trait function application for the inner application (when func is a variable)
@@ -86,7 +87,7 @@ export function handleTraitFunctionApplication(
 					traitFuncType,
 					argTypes,
 					currentState,
-					funcResult
+					allEffects
 				);
 			}
 
@@ -96,7 +97,8 @@ export function handleTraitFunctionApplication(
 					expr,
 					traitFuncType,
 					argTypes,
-					currentState
+					currentState,
+					allEffects
 				);
 			}
 		}
@@ -110,7 +112,7 @@ function handlePartialTraitFunctionApplication(
 	traitFuncType: FunctionType,
 	argTypes: Type[],
 	currentState: TypeState,
-	funcResult: TypeResult
+	allEffects: Set<Effect>
 ): TypeResult {
 	// Freshen type variables in the trait function type to avoid conflicts with argument types
 	// Create a mapping from old variable names to fresh ones
@@ -290,7 +292,7 @@ function handlePartialTraitFunctionApplication(
 			};
 		}
 	}
-	return createTypeResult(curriedType, funcResult.effects, partialState);
+	return createTypeResult(curriedType, allEffects, partialState);
 }
 
 // Helper function to handle full trait function application
@@ -298,7 +300,8 @@ function handleFullTraitFunctionApplication(
 	expr: ApplicationExpression,
 	traitFuncType: FunctionType,
 	argTypes: Type[],
-	currentState: TypeState
+	currentState: TypeState,
+	allEffects: Set<Effect>
 ): TypeResult | null {
 	let funcName = 'unknown';
 	if (expr.func.kind === 'variable') {
@@ -438,6 +441,7 @@ function handleFullTraitFunctionApplication(
 			}
 
 			const resultEffects = unionEffects(
+				allEffects,
 				traitImplType.effects,
 				...argResults.map(r => r.effects)
 			);
@@ -561,7 +565,7 @@ function handleFullTraitFunctionApplication(
 						}
 					}
 
-					return createTypeResult(resultType, new Set(), resultState);
+					return createTypeResult(resultType, allEffects, resultState);
 				}
 			}
 		}

--- a/test/features/effects/effects_phase3.test.ts
+++ b/test/features/effects/effects_phase3.test.ts
@@ -109,6 +109,20 @@ test('Effects Phase 3 - Effect Propagation in Function Composition - nested func
 	);
 });
 
+test('Effects Phase 3 - Effect Propagation in Function Composition - effects inside a deferred trait function call still propagate through application', () => {
+	// `show`'s argument type is still a polymorphic variable (x's concrete type
+	// isn't known until `announce` is applied), so trait resolution defers the
+	// constraint instead of resolving a concrete Show impl immediately. That
+	// deferred path used to drop the argument's effects entirely.
+	expectEffects(
+		`
+				announce = fn x => show (print x; x);
+				announce 5
+			`,
+		['write']
+	);
+});
+
 test('Effects Phase 3 - Effect Propagation in Function Composition - pipeline operations propagate effects', () => {
 	expectEffects(
 		`


### PR DESCRIPTION
## What

Found while verifying that effects inside template holes (#151/#153) propagate to an enclosing function, not just a directly-evaluated expression. They didn't, and the bug turned out to be unrelated to templates specifically.

## Root cause

`handleFullTraitFunctionApplication` (`src/typer/trait-function-handling.ts`) has two branches:

- One where a trait function (e.g. `show`) resolves to a concrete implementation immediately — this one correctly unions in the argument's effects.
- One that **defers** the constraint when the argument's type is still a polymorphic variable — e.g. inside a generic lambda body, before the parameter is applied to a concrete argument. This branch hardcoded `new Set()` for effects, discarding whatever the argument expression performed. The caller (`typeApplication`) had already computed the correct accumulated effects (`allEffects`) but never threaded them down into this function.

Reproduces identically with or without template syntax — it's a general trait-function/effects interaction, not template-specific:

```
`said: ${(print "hi"; 42)}`                        → effects: [write]   (direct eval, fine)
f = fn x => `said: ${(print x; x)}`; f 5            → effects: []        (bug: lost through application)
f = fn x => "said: " + show (print x; x); f 5       → effects: []        (same bug, no template syntax at all)
f = fn x => (print x; x); f 5                       → effects: [write]   (no trait function involved, fine)
```

## Fix

Threaded `allEffects` through `handleTraitFunctionApplication` → `handlePartialTraitFunctionApplication` / `handleFullTraitFunctionApplication`, replacing the dropped `new Set()` and the narrower `funcResult.effects` in the partial-application path.

## Verification

- Added a regression test (`test/features/effects/effects_phase3.test.ts`) — confirmed it's red without the fix (stashed the `src/` changes and reran) and green with it.
- Full suite: 1292 pass / 0 fail.
- `node validate_examples.js`: clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AG2p7ChoDB6t1DGAaGTVTV)_