### PR TITLE
Fix stdlib apply/join/tail and give ==/!= real Eq trait dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,10 @@ jobs:
     - name: Run tests (all migrated to bun)
       run: bun test
 
-  # Run REPL-specific tests separately  
+    - name: Run noolang test suites (noo test)
+      run: bun src/cli.ts test
+
+  # Run REPL-specific tests separately
   repl-tests:
     runs-on: ubuntu-latest
     # Removed dependencies to allow parallel execution with other jobs

--- a/docs-wip/INT_REFINEMENT_DECISION.md
+++ b/docs-wip/INT_REFINEMENT_DECISION.md
@@ -1,0 +1,36 @@
+# Float-only numbers: deliberate, with a trigger for revisiting
+
+Decision (2026-07-16): Noolang stays Float-only. This is a choice, not a TODO.
+
+## Why Float-only is correct today
+
+- JS doubles are the substrate. A fixed-width `Int64` over doubles would lie about
+  its representation — and would have to *manufacture* overflow semantics the
+  substrate doesn't exhibit. (JS numbers don't wrap; they silently lose precision
+  past 2^53. "Integer overflow" is not a hazard we have; let's not import one.)
+- No dogfooded program has yet produced a bug caused by a fractional value where
+  an integer was meant. YAGNI holds until one does.
+
+## The design to reach for if that changes: refinement Int, not fixed-width Int
+
+`Int` as a typer-level refinement of Float — "integer-valued number":
+
+- Same runtime representation (JS number). No width promise ⇒ no overflow
+  semantics to invent, nothing to check at runtime.
+- `+ - * %` close over Int. `/` already returns `Option Float`, so division —
+  the one operation that leaves the integers — already has its exit ramp.
+- What it buys is domain honesty, not arithmetic safety: `exit 1.5`,
+  `list_get 0.5`, fractional counts become type errors.
+
+## The real cost (and it isn't overflow)
+
+Numeric-literal polymorphism. Is `3` an Int or a Float? Either literals get
+constraint-typed (Haskell's `Num a => a` with defaulting rules and their
+notorious error messages) or literal syntax splits. Every numeric trait impl
+duplicates (`Add Int`, `Ord Int`, …). That's inference complexity in a language
+that optimizes for LLM-predictable inference — a genuine price.
+
+## Trigger condition
+
+Revisit when a real program hits a bug caused by a fractional value flowing
+where an integer was meant — not before. Easier to add than remove.

--- a/src/evaluator/evaluator.ts
+++ b/src/evaluator/evaluator.ts
@@ -479,9 +479,10 @@ export class Evaluator {
 		this.environment.set(
 			'tail',
 			createNativeFunction('tail', (list: Value) => {
-				if (isList(list) && list.values.length > 0)
-					return createList(list.values.slice(1));
-				throw new Error('Cannot get tail of empty list or non-list');
+				// Total on lists: tail [] = [] — matches head's no-crash safety
+				// story without breaking the guarded `match (head l) ... tail l` idiom
+				if (isList(list)) return createList(list.values.slice(1));
+				throw new Error('Cannot get tail of non-list');
 			})
 		);
 		this.environment.set(
@@ -2368,6 +2369,38 @@ export class Evaluator {
 				}
 				throw new Error(
 					`Cannot modulus ${leftVal?.tag || 'unit'} and ${rightVal?.tag || 'unit'}`
+				);
+			}
+
+			if (expr.operator === '==' || expr.operator === '!=') {
+				const negate = expr.operator === '!=';
+				const asBool = (b: boolean) => createBool(negate ? !b : b);
+				if (isNumber(leftVal) && isNumber(rightVal)) {
+					return asBool(leftVal.value === rightVal.value);
+				}
+				if (isString(leftVal) && isString(rightVal)) {
+					return asBool(leftVal.value === rightVal.value);
+				}
+				if (isUnit(leftVal) && isUnit(rightVal)) {
+					return asBool(true);
+				}
+				// Structured types (variants, lists, records) go through Eq —
+				// falling through to the primitives-only native silently
+				// returned False for all of them
+				if (this.isTraitFunction('equals')) {
+					try {
+						const result = this.resolveTraitFunctionWithArgs(
+							'equals',
+							[leftVal, rightVal],
+							this.traitRegistry
+						);
+						if (isBool(result)) return asBool(boolValue(result));
+					} catch (_e) {
+						// Fall through to error
+					}
+				}
+				throw new Error(
+					`Cannot compare ${leftVal?.tag || 'unit'} and ${rightVal?.tag || 'unit'} for equality`
 				);
 			}
 

--- a/stdlib.noo
+++ b/stdlib.noo
@@ -182,8 +182,8 @@ implement Eq (Option a) given a implements Eq (
 );
 
 implement Applicative Option (
-  apply = fn f opt => match opt (
-    Some x => f x;
+  apply = fn f opt => match f (
+    Some g => map g opt;
     None => None
   )
 );
@@ -290,6 +290,12 @@ implement Eq (Result a b) given (a implements Eq) and (b implements Eq) (
   )
 );
 
+# KNOWN WRONG: matches the argument and applies the wrapped value as a
+# function. The correct body (match f; Ok g => map g res) crashes the typer —
+# two-parameter variants register at arity 1 in trait instances, and matching
+# the `f (a -> b)` parameter hits "Unknown ADT: Result" during stdlib load.
+# Unusable either way until the typer kind bug is fixed; deferred tests in
+# stdlib.test.noo.
 implement Applicative Result (
   apply = fn f res => match res (
     Ok x => f x;
@@ -310,9 +316,13 @@ head = fn list => if (length list) == 0
   else list_get 0 list;
 
 # Join list elements with a separator
-# Example: join ", " [1, 2, 3] -> "1, 2, 3"
-join = fn separator list =>
-  reduce (fn acc x => if acc == "" then x else concat acc (concat separator x)) "" list;
+# Example: join ", " ["a", "b"] -> "a, b"
+# Head/tail split, not an acc == "" sentinel: an empty string is a real
+# element and must still get its separator.
+join = fn separator list => match (head list) (
+  None => "";
+  Some h => reduce (fn acc x => acc + separator + x) h (tail list)
+);
 
 filter = list_filter;
 

--- a/stdlib.test.noo
+++ b/stdlib.test.noo
@@ -1,0 +1,42 @@
+# Regression suite for stdlib.noo, run by `noo test`.
+# Written against three bugs found by probing (2026-07-16): Applicative apply
+# crashing on Option/Result, join dropping separators before empty elements,
+# and tail throwing on the empty list.
+
+{@test_case test_case, @group group, @expect_eq expect_eq, @expect expect} = import "std/test";
+
+applicative_tests = group "Applicative apply" [
+  test_case "Option: applies wrapped function" (fn _ =>
+    expect_eq (Some 3) (apply (Some (fn x => x + 1)) (Some 2))),
+  test_case "Option: None function short-circuits" (fn _ =>
+    expect_eq None (apply None (Some 2))),
+  test_case "Option: None argument short-circuits" (fn _ =>
+    expect_eq None (apply (Some (fn x => x + 1)) None))
+  # Result apply/map tests blocked on a typer kind bug: two-parameter variants
+  # register at arity 1 in trait instances (`map f (Ok 2)` infers `Result Float`,
+  # `apply` at Result won't type at all). Needs a typer fix, not a stdlib one.
+];
+
+join_tests = group "join" [
+  test_case "separates all elements" (fn _ =>
+    expect_eq "a, b, c" (join ", " ["a", "b", "c"])),
+  test_case "keeps separator before an empty first element" (fn _ =>
+    expect_eq ", a, b" (join ", " ["", "a", "b"])),
+  test_case "keeps separator around empty middle element" (fn _ =>
+    expect_eq "a,,b" (join "," ["a", "", "b"])),
+  test_case "empty list joins to empty string" (fn _ =>
+    expect_eq "" (join ", " [])),
+  test_case "single element has no separator" (fn _ =>
+    expect_eq "a" (join ", " ["a"]))
+];
+
+tail_tests = group "tail" [
+  test_case "tail of empty list is empty, not a crash" (fn _ =>
+    expect_eq 0 (length (tail []))),
+  test_case "tail drops exactly the head" (fn _ =>
+    expect_eq [2, 3] (tail [1, 2, 3])),
+  test_case "tail of singleton is empty" (fn _ =>
+    expect_eq 0 (length (tail [1])))
+];
+
+group "stdlib regressions" [applicative_tests, join_tests, tail_tests]

--- a/test/features/operators/equality-trait-dispatch.test.ts
+++ b/test/features/operators/equality-trait-dispatch.test.ts
@@ -1,0 +1,44 @@
+import { test, describe } from 'bun:test';
+import { expectSuccess } from '../../utils';
+
+// Regression: == and != fell through to a primitives-only native whose
+// default case returned False, so every variant/list comparison was silently
+// wrong. They now dispatch through the Eq trait like + dispatches through Add.
+describe('==/!= trait dispatch', () => {
+	test('== on Option values uses Eq', () => {
+		expectSuccess(`(Some 3) == (Some 3)`, true);
+	});
+
+	test('== distinguishes unequal Options', () => {
+		expectSuccess(`(Some 3) == (Some 4)`, false);
+	});
+
+	test('== on Some vs None', () => {
+		expectSuccess(`(Some 3) == None`, false);
+	});
+
+	test('!= negates the Eq result on variants', () => {
+		expectSuccess(`(Some 3) != (Some 4)`, true);
+	});
+
+	test('== on lists is structural', () => {
+		expectSuccess(`[2, 3] == [2, 3]`, true);
+	});
+
+	test('== on unequal lists', () => {
+		expectSuccess(`[2, 3] == [2, 4]`, false);
+	});
+
+	test('== on nested variants in lists', () => {
+		expectSuccess(`[Some 1, None] == [Some 1, None]`, true);
+	});
+
+	test('== on Bool variants', () => {
+		expectSuccess(`True == True`, true);
+	});
+
+	test('== on primitives still works', () => {
+		expectSuccess(`1 == 1`, true);
+		expectSuccess(`"a" == "b"`, false);
+	});
+});


### PR DESCRIPTION
Probing after the dogfooding pass found three stdlib bugs; fixing them uncovered a fourth, larger one in the evaluator.

## Fixes

- **`Applicative Option` apply crashed**: it matched the argument and applied the wrapped value as a function. Now matches the wrapped function and maps it. The **Result** impl has the same defect, but its correct body trips a typer kind bug — two-parameter variants register at arity 1 in trait instances (`map (fn x => x + 1) (Ok 2)` infers `Result Float`, dropping the error type; `apply` at Result won't type at all; matching the `f (a -> b)` parameter crashes stdlib load with `Unknown ADT: Result`). Left as-is with a KNOWN WRONG comment and deferred tests; the typer fix is its own project.
- **`join` dropped separators before empty elements** (`join ", " ["", "a"]` → `"a"`): the `acc == ""` sentinel treated a real empty-string element as "first". Rewritten as a head/tail split.
- **`tail []` threw** while `head` safely returned Option. Now total: `tail [] = []`, preserving the guarded `match (head l) ... tail l` idiom stdlib already uses everywhere.
- **`==`/`!=` never dispatched through Eq.** Unlike `+ - * / %`, they had no trait-resolution branch in `evaluateBinary` and fell through to a primitives-only native whose default case was `False`. Every variant/list/record comparison silently answered False — `(Some 3) == (Some 3)` was `False` on main. They now resolve `equals` the way `+` resolves `add`; types with no Eq instance get an honest runtime error instead of a silent False.

## Tests

- `stdlib.test.noo` — first `.noo` suite run by `noo test`, covering all three stdlib fixes; **CI now runs `bun src/cli.ts test`** next to `bun test` so it's not decoration.
- `test/features/operators/equality-trait-dispatch.test.ts` — TS regressions for `==`/`!=` across variants, lists, nesting, and primitives.
- Full suite 1301 pass / 0 fail, typecheck clean, doc validation green.

## Follow-ups flagged, not done here

1. `==` is still typed as unconstrained `a -> a -> Bool`; the Eq requirement belongs in the typer so no-instance comparisons fail at compile time (records currently fail at runtime).
2. The trait-instance kind bug for two-parameter variants (Result at Functor/Applicative/Monad) — deferred tests are commented in `stdlib.test.noo`.

Also carries a small docs-wip note recording the Float-only numbers decision and its revisit trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TASnoHntaoTfJZpshTGnB