### PR TITLE
Give == and != a real Eq constraint, matching Ord's < > <= >=

### DIFF
--- a/src/typer/builtins.ts
+++ b/src/typer/builtins.ts
@@ -89,13 +89,23 @@ export const initializeBuiltins = (state: TypeState): TypeState => {
 		quantifiedVars: ['a'],
 	});
 
-	// Comparison operators
+	// Comparison operators - require the type to implement Eq
+	const equalsType = functionType(
+		[typeVariable('a'), typeVariable('a')],
+		boolType()
+	);
+	equalsType.constraints = [implementsConstraint('a', 'Eq')];
 	newEnv.set('==', {
-		type: functionType([typeVariable('a'), typeVariable('a')], boolType()),
+		type: equalsType,
 		quantifiedVars: ['a'],
 	});
+	const notEqualsType = functionType(
+		[typeVariable('a'), typeVariable('a')],
+		boolType()
+	);
+	notEqualsType.constraints = [implementsConstraint('a', 'Eq')];
 	newEnv.set('!=', {
-		type: functionType([typeVariable('a'), typeVariable('a')], boolType()),
+		type: notEqualsType,
 		quantifiedVars: ['a'],
 	});
 	// Ordering operators - require the type to implement Ord

--- a/test/features/operators/equality-trait-dispatch.test.ts
+++ b/test/features/operators/equality-trait-dispatch.test.ts
@@ -1,5 +1,5 @@
-import { test, describe } from 'bun:test';
-import { expectSuccess } from '../../utils';
+import { test, describe, expect } from 'bun:test';
+import { expectSuccess, expectError, runCode } from '../../utils';
 
 // Regression: == and != fell through to a primitives-only native whose
 // default case returned False, so every variant/list comparison was silently
@@ -40,5 +40,40 @@ describe('==/!= trait dispatch', () => {
 	test('== on primitives still works', () => {
 		expectSuccess(`1 == 1`, true);
 		expectSuccess(`"a" == "b"`, false);
+	});
+});
+
+// Regression: == was typed as unconstrained `a -> a -> Bool`, so a type with
+// no Eq instance (records have none) only failed inside the evaluator's
+// trait-resolution fallback — the type system waved it through with no
+// static check at all. == and != now carry the operator-scheme constraint
+// `given a implements Eq`, the same mechanism `<`/`>`/Ord already use: a
+// concrete no-instance type is rejected during typeBinary (before
+// evaluation), while an unresolved polymorphic use defers the constraint
+// rather than erroring. (Note: like Ord, this constraint is enforced at the
+// call site and does not appear in the generalized function type's printed
+// signature the way Add's does — different mechanism, same static coverage.)
+describe('==/!= Eq constraint', () => {
+	test('comparing a concrete no-Eq-instance type fails during type-checking', () => {
+		expectError(
+			`{@a 1} == {@a 1}`,
+			/No implementation found for operator ==/
+		);
+	});
+
+	test('!= on a concrete no-Eq-instance type also fails during type-checking', () => {
+		expectError(
+			`{@a 1} != {@a 1}`,
+			/No implementation found for operator !=/
+		);
+	});
+
+	test('a polymorphic, unresolved == use is not rejected eagerly', () => {
+		const { finalType } = runCode(`fn a b => a == b`);
+		expect(finalType).toBe('a -> a -> Bool');
+	});
+
+	test('== still resolves normally once operands are concrete and Eq-able', () => {
+		expectSuccess(`(fn a b => a == b) 1 1`, true);
 	});
 });

--- a/test/features/operators/equality-trait-dispatch.test.ts
+++ b/test/features/operators/equality-trait-dispatch.test.ts
@@ -1,9 +1,8 @@
 import { test, describe, expect } from 'bun:test';
 import { expectSuccess, expectError, runCode } from '../../utils';
 
-// Regression: == and != fell through to a primitives-only native whose
-// default case returned False, so every variant/list comparison was silently
-// wrong. They now dispatch through the Eq trait like + dispatches through Add.
+// Regression: == and != had no trait-resolution fallback, so every
+// variant/list comparison silently returned False.
 describe('==/!= trait dispatch', () => {
 	test('== on Option values uses Eq', () => {
 		expectSuccess(`(Some 3) == (Some 3)`, true);
@@ -43,16 +42,9 @@ describe('==/!= trait dispatch', () => {
 	});
 });
 
-// Regression: == was typed as unconstrained `a -> a -> Bool`, so a type with
-// no Eq instance (records have none) only failed inside the evaluator's
-// trait-resolution fallback — the type system waved it through with no
-// static check at all. == and != now carry the operator-scheme constraint
-// `given a implements Eq`, the same mechanism `<`/`>`/Ord already use: a
-// concrete no-instance type is rejected during typeBinary (before
-// evaluation), while an unresolved polymorphic use defers the constraint
-// rather than erroring. (Note: like Ord, this constraint is enforced at the
-// call site and does not appear in the generalized function type's printed
-// signature the way Add's does — different mechanism, same static coverage.)
+// Regression: == and != were unconstrained, so a no-Eq type only failed at
+// runtime. Now Eq-constrained like Ord's < > — enforced at the call site,
+// not shown in a generalized signature (same as <).
 describe('==/!= Eq constraint', () => {
 	test('comparing a concrete no-Eq-instance type fails during type-checking', () => {
 		expectError(


### PR DESCRIPTION
Follow-up to #156: == and != were unconstrained, so no-Eq types (records) only failed at runtime.

- Eq-constrained like Ord's < > <= >= — rejected during type-checking, not eval
- Enforced at call site, doesn't show in a generalized signature (matches < 's existing behavior)
- Tests: test/features/operators/equality-trait-dispatch.test.ts
- Full suite / typecheck / docs / noo test all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)