### PR TITLE
Extend stdlib.test.noo coverage; file import-destructure arity bug

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,16 @@ primitive.
 
 TDD: write the failing test first, confirm it's red, then fix.
 
+`stdlib.test.noo` (run via `noo test`, not `bun test`) is a narrow complement,
+not an alternative: it exercises `stdlib.noo` as an imported module, the way a
+real program does, and it's the only thing that also validates `std/test`
+itself end to end. It caught a bug (module-destructure arity corrupting
+unrelated inference) that isolated TS snippets didn't reproduce. It cannot
+assert on inferred types or error messages (`Expectation` only wraps runtime
+Pass/Fail), and every test in the file shares one type-inference pass, so it's
+more fragile than TS's per-test isolation. Default to TS; add here only for
+"does stdlib work as consumed."
+
 ## Language quick facts
 
 - ADTs use `variant Name = A | B`; `type` is for aliases (`type Point = {Float, Float}`).

--- a/docs-wip/IMPORT_DESTRUCTURE_ARITY_BUG.md
+++ b/docs-wip/IMPORT_DESTRUCTURE_ARITY_BUG.md
@@ -1,0 +1,84 @@
+# Destructuring N+1 fields from a module import corrupts unrelated inference
+
+Filed 2026-07-23, found while adding stdlib.test.noo coverage.
+
+## Symptom
+
+`stdlib.test.noo`'s import line was, as committed and passing:
+
+    {@test_case test_case, @group group, @expect_eq expect_eq, @expect expect} = import "std/test";
+
+Adding a fifth field to the same destructuring pattern — any field, and
+whether or not the new binding is ever used — breaks type inference on an
+unrelated expression later in the same file:
+
+    {@test_case test_case, @group group, @expect_eq expect_eq, @expect expect, @fail fail} = import "std/test";
+    ...
+    expect_eq "a, b, c" (join ", " ["a", "b", "c"])   # <- fails here
+
+    TypeError: Function application type mismatch in applying argument 1
+      Expected: Option Float
+      Got:      String
+
+`expect_eq`'s parameter type is somehow being pinned to `Option Float` (the
+type it resolves to for the *first* group in the file, which compares
+`Option` values) rather than generalized per call site, and only once a 5th
+field is pulled from the import.
+
+## Confirmed general, not `expect_all`-specific
+
+Reproduced with four different unused 5th fields (`@fail`, `@expect_ok`,
+`@run_tree`, `@expect_all`) — same error, same location, every time. Field
+*count* in one destructuring pattern is the trigger, not which field.
+
+## Not reproducible in isolation
+
+A minimal record literal destructured at varying arity (1-5 fields, no
+import) does not reproduce it. A minimal `import "std/test"` destructure
+combined with a trivial `join`/`==` expression does not reproduce it either.
+It needs the fuller file: multiple `test_case`/`expect_eq` call sites at
+different concrete types (`Option Float` in one group, `String` in another),
+plus the module import, plus the extra destructured field. Not yet reduced
+further — whoever picks this up should start from `/tmp/orig.noo` +
+`/tmp/vary_1.noo` pattern in this session's transcript, or reconstruct from
+stdlib.test.noo's pre-bug-discovery version (the git history around the
+commit "Fix stdlib apply/join/tail...").
+
+## Workaround (in use)
+
+Split the import into two destructuring statements instead of one wider one:
+
+    {@test_case test_case, @group group, @expect_eq expect_eq, @expect expect} = import "std/test";
+    {@expect_all expect_all} = import "std/test";
+
+Confirmed this avoids the bug. stdlib.test.noo uses this pattern for
+`expect_all`.
+
+## Suspicion, not confirmed
+
+Given the workaround shape, this smells like the module-import typing path
+narrowing/closing the imported record's row type based on destructured
+arity, and that narrowing leaking mutable substitution state into the host
+file's later, unrelated unification — rather than each `test_case`/
+`expect_eq` call site being independently generalized. Not verified against
+the actual typer code; whoever picks this up should start in
+`src/typer/` wherever record-destructuring definitions and module imports
+are typed (likely `type-inference.ts`'s destructuring-definition handling
+and the import-typing path referenced in `test/import-typing.test.ts`).
+
+## Why not fixed now
+
+Found mid-task while adding stdlib test coverage (unrelated goal), and the
+workaround is cheap and sufficient for that task. This is a correctness bug
+in the typer's handling of record-destructuring imports, not scoped to
+stdlib — could affect any program that imports more names from a module.
+Severity is real (silent, unrelated type corruption) but a full
+investigation is its own project matching CLAUDE.md's type-inference hazard
+description almost exactly: "goes green and wrong at the same time."
+
+## Trigger for picking this up
+
+Should be picked up soon regardless of a new trigger event — this is a
+correctness bug with a cheap, already-demonstrated workaround, not a
+speculative gap. Suggested next step: reduce the repro further (bisect the
+file content, not just field count) before touching the typer.

--- a/stdlib.test.noo
+++ b/stdlib.test.noo
@@ -1,7 +1,6 @@
-# Regression suite for stdlib.noo, run by `noo test`.
-# Written against three bugs found by probing (2026-07-16): Applicative apply
-# crashing on Option/Result, join dropping separators before empty elements,
-# and tail throwing on the empty list.
+# Runtime regression suite for stdlib.noo, run by `noo test` (not `bun test`).
+# Complements test/ (TS) rather than replacing it — see CLAUDE.md's Tests
+# section for the split. No type-level assertions here.
 
 {@test_case test_case, @group group, @expect_eq expect_eq, @expect expect} = import "std/test";
 # Split import: destructuring a 5th field from the same statement corrupts

--- a/stdlib.test.noo
+++ b/stdlib.test.noo
@@ -4,6 +4,10 @@
 # and tail throwing on the empty list.
 
 {@test_case test_case, @group group, @expect_eq expect_eq, @expect expect} = import "std/test";
+# Split import: destructuring a 5th field from the same statement corrupts
+# unrelated type inference elsewhere in this file. See
+# docs-wip/IMPORT_DESTRUCTURE_ARITY_BUG.md.
+{@expect_all expect_all} = import "std/test";
 
 applicative_tests = group "Applicative apply" [
   test_case "Option: applies wrapped function" (fn _ =>
@@ -39,4 +43,54 @@ tail_tests = group "tail" [
     expect_eq 0 (length (tail [1])))
 ];
 
-group "stdlib regressions" [applicative_tests, join_tests, tail_tests]
+# Tuples have no Eq instance (the trait system is nominal-type-only, and
+# tuples are structural), so these check behavior via assoc_get lookups
+# rather than comparing association lists structurally.
+assoc_tests = group "assoc_get/set/update" [
+  test_case "assoc_get finds an existing key" (fn _ =>
+    expect_eq (Some 2) (assoc_get "b" [{"a", 1}, {"b", 2}])),
+  test_case "assoc_get on a missing key is None" (fn _ =>
+    expect_eq None (assoc_get "z" [{"a", 1}])),
+  test_case "assoc_set replaces an existing key's value" (fn _ =>
+    expect_eq (Some 9) (assoc_get "b" (assoc_set "b" 9 [{"a", 1}, {"b", 2}]))),
+  test_case "assoc_set appends a new key without dropping existing ones" (fn _ =>
+    expect_all [
+      expect_eq (Some 1) (assoc_get "a" (assoc_set "c" 9 [{"a", 1}])),
+      expect_eq (Some 9) (assoc_get "c" (assoc_set "c" 9 [{"a", 1}]))
+    ]),
+  test_case "assoc_update applies f to an existing value" (fn _ =>
+    expect_eq (Some 3) (assoc_get "b" (assoc_update "b" (fn v => v + 1) 0 [{"a", 1}, {"b", 2}]))),
+  test_case "assoc_update inserts the default for a missing key" (fn _ =>
+    expect_eq (Some 0) (assoc_get "z" (assoc_update "z" (fn v => v + 1) 0 [{"a", 1}])))
+];
+
+sort_by_tests = group "sort_by/insert_sorted_by" [
+  test_case "sort_by orders using the given predicate" (fn _ =>
+    expect_eq [3, 2, 1] (sort_by (fn a b => a > b) [3, 1, 2])),
+  test_case "insert_sorted_by inserts at the right position" (fn _ =>
+    expect_eq [9, 5, 3, 1] (insert_sorted_by (fn a b => a > b) 5 [9, 3, 1]))
+];
+
+result_option_tests = group "Result/Option helpers" [
+  test_case "map_err transforms Err" (fn _ =>
+    expect_eq (Err "wrapped: boom") (map_err (fn e => "wrapped: " + e) (Err "boom"))),
+  test_case "map_err leaves Ok untouched" (fn _ =>
+    expect_eq (Ok 5) (map_err (fn e => "wrapped: " + e) (Ok 5))),
+  test_case "option_get_or unwraps Some" (fn _ =>
+    expect_eq 5 (option_get_or 0 (Some 5))),
+  test_case "option_get_or falls back on None" (fn _ =>
+    expect_eq 0 (option_get_or 0 None)),
+  test_case "result_get_or unwraps Ok" (fn _ =>
+    expect_eq 5 (result_get_or 0 (Ok 5))),
+  test_case "result_get_or falls back on Err" (fn _ =>
+    expect_eq 0 (result_get_or 0 (Err "e"))),
+  test_case "is_ok/is_err agree on Ok" (fn _ =>
+    expect_all [expect "is_ok Ok" (is_ok (Ok 5)), expect "not is_err Ok" (not (is_err (Ok 5)))]),
+  test_case "is_ok/is_err agree on Err" (fn _ =>
+    expect_all [expect "not is_ok Err" (not (is_ok (Err "e"))), expect "is_err Err" (is_err (Err "e"))])
+];
+
+group "stdlib regressions" [
+  applicative_tests, join_tests, tail_tests,
+  assoc_tests, sort_by_tests, result_option_tests
+]


### PR DESCRIPTION
- Coverage for assoc_get/set/update, sort_by/insert_sorted_by, map_err, option_get_or, result_get_or, is_ok/is_err — all previously untested, all correct
- assoc_* tests use assoc_get lookups, not structural list equality — tuples have no Eq instance (nominal-type-only trait system, tuples are structural)
- Found a real typer bug mid-task: destructuring a 5th field from one `import "std/test"` statement corrupted type inference on an unrelated expression elsewhere in the file — filed with repro + workaround in docs-wip/IMPORT_DESTRUCTURE_ARITY_BUG.md
- Full suite / typecheck / docs / noo test all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)