### PR TITLE
LSP diagnostic location fix, silent-by-default script execution

### DIFF
--- a/docs-wip/JSON_PARSER_PLAN.md
+++ b/docs-wip/JSON_PARSER_PLAN.md
@@ -1,0 +1,106 @@
+# JSON Parser Plan
+
+A JSON parser/serializer for noolang, as the next stdlib-gap forcing function
+(same pattern as word-count → string primitives, find_todos → &&/||, the test
+runner → exec hardening). Confirmed via spike (2026-07-23): no prerequisite
+work needed, representation decided, not yet implemented.
+
+## Scope
+
+Parse + serialize, hand-written recursive-descent in pure `.noo` — not a
+native builtin wrapping JS `JSON.parse`. A native wrapper would be correct
+immediately but defeats the point: this exercise exists to find real stdlib
+gaps (the way word-count found missing string primitives), and a native
+implementation papers over exactly the gaps it would otherwise surface.
+
+## Representation: concrete `JsonValue` variant, not `Unknown`
+
+```
+variant JsonValue = JNull | JBool Bool | JNumber Float | JString String
+                   | JArray (List JsonValue) | JObject (List {String, JsonValue});
+```
+
+This was not the first design considered — worth recording why, since the
+detour surfaces real constraints on `Unknown` that matter beyond this task.
+
+### Why not `Unknown` (the `schema.noo` approach)
+
+A deleted prototype, `schema.noo` (removed in #129, recoverable via
+`git show 076e4bb^:schema.noo`), built a decode-combinator layer:
+`Schema a = Unknown -> Result a DecodeError`, with `string_schema`/
+`list_schema`/etc. on top of the `isString`/`isNumber`/`isBool`/`isList`
+refinement builtins. Initial plan was to reuse it directly: parse JSON text
+into `Unknown`, decode with schema-style combinators.
+
+Spiking that plan found two blocking issues:
+
+1. **Records can't be constructed with runtime-computed keys.**
+   `k = "a"; {@k 1}` types the field literally as `k`, not as the value of
+   `k` — noolang record literals only support statically-known field names.
+   JSON object keys are only known at parse time, so a JSON object can never
+   become a noolang record in the first place, `Unknown`-wrapped or not.
+   Arrays don't have this problem (`List` doesn't need static per-element
+   declaration), so this only blocks objects — see `assoc_get`/`assoc_set`
+   (#130) for the existing `List {String, a}` answer to "map with runtime
+   keys," which was the fallback considered.
+
+2. **`Unknown` can't recover tuple/record shapes at all.** Only
+   `isString`/`isNumber`/`isBool`/`isList` exist as refinement builtins — no
+   `isTuple`, no `isRecord`. So even the `List {String, Unknown}` fallback
+   for objects has no way to decode back out of `Unknown` once wrapped; only
+   4 of JSON's 6 kinds round-trip through it. A JSON value recurses in every
+   direction (object-of-array, array-of-object, ...) and needs one uniform
+   recursive type — `Unknown` only uniformly covers part of that.
+
+The deeper realization, once both of those surfaced: **`Unknown` and a
+hand-rolled parser are solving different problems, not competing solutions
+to the same one.** `Unknown`'s actual job (see
+[[ffi-abandoned-exec-is-escape-hatch]] in project memory) is blessing a value
+that arrives *already shaped* from outside noolang's type checker — FFI,
+`exec` output, a hypothetical native `JSON.parse` builtin — into safe typed
+data via `forget` (erase) + refinement (recover). A hand-written `.noo`
+parser never crosses that boundary: nothing foreign hands it a shape, it
+*constructs* the shape itself, from text, entirely under noolang's own typed
+construction rules. There's nothing to erase, so there's nothing for
+`Unknown` to be doing.
+
+`schema.noo` was correct for what it was built for and stays parked for that
+purpose (do not revive it for this task). Its *pattern* — `Result`-returning
+validators, a `DecodeError` variant, composable extractors — still informs a
+clean query/extraction API over `JsonValue` once parsed; only the erase/
+recover machinery underneath it doesn't apply here.
+
+## Spike findings (2026-07-23) — no prerequisite work needed
+
+Confirmed all buildable in current noolang, no new builtins required:
+
+- Recursion works (`fn n => if n == 0 then ... else 1 + rec (n - 1)`).
+- `chars : String -> List String`, `substring`, `indexOf` sufficient for
+  char-by-char scanning (no `Char` type — 1-char strings stand in).
+- `Monad`/`Functor` instances exist for `Result`, `Option`, `List` — parser
+  combinators (sequencing, mapping over parse results) are viable now.
+- `list_get`/`at`, `assoc_get`/`assoc_set` (#130) available if a
+  `List {String, JsonValue}` needs dict-like lookup during extraction.
+
+## Also considered and parked
+
+A `.noo`-native source-code formatter was raised as an alternative forcing
+function during scoping. Parked, not related to JSON — it needs
+comment-preserving lexer trivia (currently `skipComment()` discards comments
+outright, never producing a token) and an AST-as-value builtin design before
+a formatter is buildable in userland at all. Real future work, but a
+multi-session prerequisite chain, not this task.
+
+## Where to start
+
+1. Tokenizer: JSON text → token stream (or straight to recursive-descent
+   parse, tokenizer may be unnecessary at this grammar's size).
+2. Parser: tokens/text → `JsonValue`, `Result JsonValue ParseError`.
+3. Serializer: `JsonValue -> String`, handling string escaping and number
+   formatting.
+4. Extraction API over `JsonValue`, `schema.noo`-flavored (`Result`-based,
+   composable), for pulling typed values out of a parsed object/array.
+
+Naming: stdlib is standardizing on `snake_case` (issue #131, decided
+2026-07-23, not yet executed as a rename pass) — new JSON functions should
+follow that from the start rather than adding to the inconsistency.

--- a/find_todos.noo
+++ b/find_todos.noo
@@ -9,7 +9,7 @@ has_substr = fn needle line =>
 
 scan_line = fn path idx line =>
   if (has_substr "TODO" line) || (has_substr "FIXME" line)
-    then println (concat path (concat ":" (concat (toString (idx + 1)) (concat ": " (trim line)))))
+    then println `${path}:${toString (idx + 1)}: ${trim line}`
     else {};
 
 scan_lines = fn path idx lines =>
@@ -22,6 +22,10 @@ scan_lines = fn path idx lines =>
   );
 
 scan_file = fn path =>
-  scan_lines path 0 (split "\n" (readFile path));
+  match (readFile path) (
+    Ok content => scan_lines path 0 (split "\n" content);
+    Err e => println `${path}: ${show e}`
+  );
 
-reduce (fn acc path => (scan_file path; acc)) {} argv
+argv | list_map (fn path => (scan_file path; {}));
+println "Done"

--- a/lsp/extension/package-lock.json
+++ b/lsp/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "noolang-lsp",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "noolang-lsp",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "vscode-languageclient": "^8.1.0",

--- a/lsp/extension/server/src/server.ts
+++ b/lsp/extension/server/src/server.ts
@@ -77,8 +77,8 @@ function parseTypesOutput(output: string): string[] {
   return types;
 }
 
-function cleanErrorMessage(line: string): string {
-  let message = line;
+function cleanErrorMessage(text: string): string {
+  let message = text;
   const prefixes = ['Error:', 'TypeError:', 'Parse error:'];
   for (const p of prefixes) {
     const idx = message.indexOf(p);
@@ -87,7 +87,13 @@ function cleanErrorMessage(line: string): string {
       break;
     }
   }
-  message = message.replace(/\s+at line \d+(?:, column \d+)?/g, '');
+  // Drop the "at line X, column Y" line on its own — its info is already
+  // carried by the diagnostic's range, and leaving it in duplicates it in
+  // the hover text.
+  message = message
+    .split(/\r?\n/)
+    .filter((l) => !/^\s*at line \d+(?:, column \d+)?\s*$/.test(l))
+    .join('\n');
   return message.trim();
 }
 
@@ -115,47 +121,44 @@ function extractLineColumn(line: string): { line: number; column: number } | und
 
 function getDiagnostics(filePath: string): Diagnostic[] {
   const result = runNodeCli(['--types-file', filePath]);
+  if (result.status === 0) return []; // clean typecheck — stdout is a Types: dump, not an error
   const stdout = result.stdout || '';
   const stderr = result.stderr || '';
-  const diags: Diagnostic[] = [];
+  const raw = stderr.trim() ? stderr : stdout;
+  if (!raw.trim()) return [];
 
-  const processLine = (line: string) => {
-    if (!line) return;
-    if (/(Error|TypeError|Parse error)/.test(line)) {
-      const loc = extractLineColumn(line);
-      const message = cleanErrorMessage(line);
-      const sev = /warning/i.test(line)
-        ? DiagnosticSeverity.Warning
-        : /info/i.test(line)
-        ? DiagnosticSeverity.Information
-        : DiagnosticSeverity.Error;
-      const l = (loc?.line ?? 1) - 1; // 0-based
-      const c = (loc?.column ?? 1) - 1;
-      diags.push({
-        range: {
-          start: { line: l, character: c },
-          end: { line: l, character: c + 1 },
-        },
-        severity: sev,
-        source: 'noolang',
-        message,
-      });
-    }
-  };
-
-  stderr.split(/\r?\n/).forEach(processLine);
-  if (result.status !== 0 && /Error/.test(stdout)) stdout.split(/\r?\n/).forEach(processLine);
-
-  if (diags.length === 0 && (stderr.trim() || stdout.trim())) {
-    diags.push({
-      range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } },
-      severity: DiagnosticSeverity.Error,
-      source: 'noolang',
-      message: `Error: ${stderr.trim() || stdout.trim()}`,
-    });
+  // The CLI reports one error per failing run as a single multi-line write
+  // (message, "Expected"/"Got", "at line X, column Y", an optional 💡 tip) —
+  // not one error per output line. Scan the whole block for its one
+  // location and emit one diagnostic, rather than matching line-by-line
+  // (which both loses the location, on its own line, and false-positives
+  // on lines that merely contain the substring "Error", e.g. "ReadError").
+  const lines = raw.split(/\r?\n/);
+  let loc: { line: number; column: number } | undefined;
+  for (const line of lines) {
+    loc = extractLineColumn(line);
+    if (loc) break;
   }
 
-  return diags;
+  const firstMeaningfulLine = lines.find((l) => l.trim()) || raw;
+  const sev = /warning/i.test(firstMeaningfulLine)
+    ? DiagnosticSeverity.Warning
+    : DiagnosticSeverity.Error;
+
+  const l = (loc?.line ?? 1) - 1; // 0-based
+  const c = (loc?.column ?? 1) - 1;
+
+  return [
+    {
+      range: {
+        start: { line: l, character: c },
+        end: { line: l, character: c + 1 },
+      },
+      severity: sev,
+      source: 'noolang',
+      message: cleanErrorMessage(raw),
+    },
+  ];
 }
 
 function getTypeInfo(filePath: string): string[] {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -28,6 +28,9 @@ function printUsage() {
 		`       ${colorize.command('noo --symbol-type <file> <symbol>')}`
 	);
 	console.log(`       ${colorize.command('noo --benchmark <file>')}`);
+	console.log(
+		`       ${colorize.command('noo --verbose <file>')} (or -v; prints the final value and its type, like --eval does)`
+	);
 	console.log('');
 	console.log(colorize.section('Examples:'));
 	console.log(`  ${colorize.identifier('noo my_program.noo')}`);
@@ -440,7 +443,13 @@ async function main() {
 
 	// Check for --benchmark flag
 	const isBenchmark = args.includes('--benchmark');
-	const fileArgs = args.filter(arg => arg !== '--benchmark');
+	// Script execution (`noo file.noo`) prints only what the program itself
+	// prints, like any other CLI tool — the trailing value/type dump is a
+	// REPL/probe affordance, opt in with --verbose when you want it.
+	const isVerbose = args.includes('--verbose') || args.includes('-v');
+	const fileArgs = args.filter(
+		arg => arg !== '--benchmark' && arg !== '--verbose' && arg !== '-v'
+	);
 
 	// If not --eval, treat as file
 	const file = fileArgs[0];
@@ -505,9 +514,11 @@ async function main() {
 		const cyan = (s: string) => `\x1b[36m${s}\x1b[0m`;
 		const gray = (s: string) => `\x1b[90m${s}\x1b[0m`;
 
-		console.log(valueStr);
-		if (typeStr) {
-			console.log(cyan('Type: ') + cyan(typeStr));
+		if (isVerbose) {
+			console.log(valueStr);
+			if (typeStr) {
+				console.log(cyan('Type: ') + cyan(typeStr));
+			}
 		}
 
 		// Performance measurements

--- a/test/integration/entry-file-relative-import.test.ts
+++ b/test/integration/entry-file-relative-import.test.ts
@@ -26,7 +26,8 @@ function runCli(cliArgs: string[]): string {
 }
 
 test('running a file resolves its relative imports from the file dir, not CWD', () => {
-	expect(runCli([join(dir, 'main.noo')])).toContain('42');
+	// --verbose: plain execution no longer auto-prints the final value.
+	expect(runCli(['--verbose', join(dir, 'main.noo')])).toContain('42');
 });
 
 test('--types-file resolves relative imports from the file dir, not CWD', () => {

--- a/test/integration/module-resolution-phase2.test.ts
+++ b/test/integration/module-resolution-phase2.test.ts
@@ -283,7 +283,8 @@ describe('STDLIB-CWD: stdlib loads regardless of working directory', () => {
 		const cliPath = path.join(projectRoot, 'src', 'cli.ts');
 
 		// Run from /tmp (a directory that does NOT contain stdlib.noo)
-		const result = spawnSync('bun', [cliPath, nooFile], {
+		// --verbose: plain execution no longer auto-prints the final value.
+		const result = spawnSync('bun', [cliPath, '--verbose', nooFile], {
 			cwd: '/tmp',
 			timeout: 30000,
 			encoding: 'utf8',


### PR DESCRIPTION
## Summary
- LSP: `getDiagnostics` matched CLI error output line-by-line, losing the error's location (on its own line) and false-positiving duplicate diagnostics on lines merely containing the substring "Error" (e.g. `ReadError`). Now scans the whole error block once, emits one correctly-located diagnostic.
- CLI: `noo file.noo` no longer auto-prints the final value/type after every run — that's REPL/probe behavior, not script-execution behavior. Gated behind `--verbose`/`-v`. `--eval`/`-e` and `--types*` are unchanged.
- `find_todos.noo`: fixed a real type error (`readFile` returns `Result String ReadError`, was passed straight into `split`), switched to template-string interpolation.
- `docs-wip/JSON_PARSER_PLAN.md`: scoping notes for the next stdlib forcing-function program (JSON parser/serializer in pure `.noo`).

## Test plan
- [x] `bun run typecheck`
- [x] `AGENT=1 bun test` — 1313 pass / 0 fail
- [x] `node validate_examples.js` — exit 0
- [x] Manually verified LSP diagnostic location/message against `find_todos.noo`'s original bug, in VS Code, before and after reinstalling the extension

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TASnoHntaoTfJZpshTGnB