### PR TITLE
Implement missing $ operator; attach locations to pattern-matching errors

### DIFF
--- a/docs-wip/POINT_FREE_MATCH_PLAN.md
+++ b/docs-wip/POINT_FREE_MATCH_PLAN.md
@@ -1,0 +1,76 @@
+# Point-free `match` (Haskell `\case` equivalent)
+
+Scoping note, not yet implemented. Raised while looking at `find_todos.noo`:
+`fn foo => match (foo) (...)` can't be eta-reduced to point-free form, because
+`match` is special syntax (`match <scrutinee> (<arms>)`), not a curried
+function value — there's nothing to eta-reduce *to*.
+
+## Why not make `match` a real function value
+
+The tempting "real" fix — give `match` a genuine curried type so
+`match (arms)` is just partial application — was considered and rejected.
+Exhaustiveness checking currently runs against the scrutinee's known type at
+the match site; making `match` a first-class value means deferring that
+check to wherever the resulting function gets applied, which could be a
+different module entirely. That's a real typer redesign, and lands squarely
+in the hazard CLAUDE.md already calls out: constraint/inference code goes
+green and wrong at the same time. Not worth it for a stylistic win.
+
+## The actual fix: syntax sugar, not semantics
+
+Same category as operator sectioning (#133, `src/parser/parser.ts` around
+line 336, `parseOperatorSection`): a pure parse-time desugaring, no typer
+changes. That precedent synthesizes a lambda with fresh params
+(`__section_a`, `__section_b`) wrapping a `BinaryExpression` that references
+them.
+
+Same shape here: `match (arms)` with the scrutinee omitted desugars to
+`fn __match_x => match __match_x (arms)` — a synthetic `FunctionExpression`
+wrapping an ordinary `MatchExpression`. `match` itself, its typing, and its
+exhaustiveness checking are all untouched; only the parser changes.
+
+Current grammar, for reference (`src/parser/parser.ts:1855-1878`,
+`parseMatchExpression`): `match` keyword, then a required scrutinee via
+`parseThrush`, then `(`, semicolon-separated `pattern => expr` cases, `)`.
+The scrutinee is not optional today — this is the one production that needs
+a new branch.
+
+## The real risk: `match (` is ambiguous
+
+`match (foo) (arms)` — a parenthesized scrutinee — and the proposed
+`match (arms)` — point-free, no scrutinee — both start with `match (`. The
+parser can't tell which it's looking at from the `(` alone; it has to look
+inside.
+
+Proposed disambiguation: after `match`, attempt to parse
+`( sepBy(pattern => expr, ;) )` first (the arms form). If that succeeds,
+it's point-free. If it fails, backtrack and parse the existing
+`scrutinee (arms)` form. This is ordinary PEG-style ordered-choice
+backtracking, consistent with how this parser already uses `C.choice`/
+`C.lazy` elsewhere — not a new parsing technique.
+
+Where this could still collide: a parenthesized scrutinee whose first
+token could also start a pattern. Patterns start with constructor names,
+literals, identifiers, wildcards, or destructuring syntax — normal
+expressions mostly don't start the same way `pattern =>` does, since `=>`
+isn't a general infix operator outside `fn`/`match`. No concrete collision
+found by inspection, but this needs an actual spike — write both forms
+side by side, including deliberately adversarial cases (e.g. a scrutinee
+that's itself a bare identifier or a parenthesized single-arg lambda) —
+before implementation, not asserted confidently here.
+
+## Scope if this goes ahead
+
+1. Spike the ambiguity above first — if a real collision turns up, this
+   whole approach needs rethinking (e.g. a different point-free spelling
+   that doesn't share `match (`'s prefix).
+2. Parser: new branch in `parseMatchExpression`, desugaring to a
+   `FunctionExpression` per the operator-sectioning precedent.
+3. `docs/language-reference.md` — "Pattern Matching and Exhaustiveness"
+   section (line ~504) needs the new form documented alongside the
+   existing one.
+4. Regression tests mirroring `operator-sectioning`'s test file, plus a
+   case exercising the ambiguity spike found in step 1.
+
+No stdlib or typer changes anticipated — confirm that stays true once the
+spike is done.

--- a/examples/demo.noo
+++ b/examples/demo.noo
@@ -87,8 +87,7 @@ composed_reverse_result = 10 | composed_reverse;
 complex_without_dollar = map (fn x => x * 2) (filter (fn x => x > 5) [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
 # With $ - much cleaner and more readable
-# FIXME $ should work here
-# complex_with_dollar = map (fn x => x * 2) $ filter (fn x => x > 5) [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+complex_with_dollar = map (fn x => x * 2) $ filter (fn x => x > 5) [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 
 # ========================================
 # 8. MUTATION (LOCAL MUTATION)

--- a/examples/demo.noo
+++ b/examples/demo.noo
@@ -87,7 +87,8 @@ composed_reverse_result = 10 | composed_reverse;
 complex_without_dollar = map (fn x => x * 2) (filter (fn x => x > 5) [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
 # With $ - much cleaner and more readable
-complex_with_dollar = map (fn x => x * 2) $ filter (fn x => x > 5) $ [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+# FIXME $ should work here
+# complex_with_dollar = map (fn x => x * 2) $ filter (fn x => x > 5) [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 
 # ========================================
 # 8. MUTATION (LOCAL MUTATION)
@@ -207,9 +208,8 @@ record_count = length record_list;
 # ========================================
 
 # Option type for handling nullable values safely
-safe_divide = fn a b => if b == 0 then None else Some (a / b);
-division_result = safe_divide 10 2;
-zero_division = safe_divide 10 0;
+division_result = 10 / 2;
+zero_division = 10 / 0;
 
 # Pattern matching on Option
 handle_option = fn opt => match opt (
@@ -282,7 +282,8 @@ triangle = Triangle 3 4 5;
 calculate_area = fn shape => match shape (
   Circle radius => radius * radius * 3;
   Rectangle width height => width * height;
-  Triangle a b c => (a * b) / 2
+  # TODO this is awkward
+  Triangle a b c => match ((a * b) / 2) (Some x => x; None => 0)
 );
 
 circle_area = calculate_area circle;

--- a/find_todos.noo
+++ b/find_todos.noo
@@ -9,7 +9,7 @@ has_substr = fn needle line =>
 
 scan_line = fn path idx line =>
   if (has_substr "TODO" line) || (has_substr "FIXME" line)
-    then println `${path}:${toString (idx + 1)}: ${trim line}`
+    then println `${path}:${idx + 1}: ${trim line}`
     else {};
 
 scan_lines = fn path idx lines =>
@@ -27,5 +27,5 @@ scan_file = fn path =>
     Err e => println `${path}: ${show e}`
   );
 
-argv | list_map (fn path => (scan_file path; {}));
+argv | list_map scan_file;
 println "Done"

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -1023,7 +1023,7 @@ const parseCompose = C.map(
 );
 
 // --- Thrush (|) and Safe Thrush (|?) ---
-const parseThrush: C.Parser<Expression> = C.map(
+const parseThrushBase: C.Parser<Expression> = C.map(
 	C.seq(
 		parseCompose,
 		C.many(C.seq(C.choice2(C.operator('|'), C.operator('|?')), parseCompose))
@@ -1042,6 +1042,35 @@ const parseThrush: C.Parser<Expression> = C.map(
 		return result;
 	}
 );
+
+// --- Dollar ($) ---
+// Lowest-precedence, right-associative function application: `f $ g $ x` is
+// `f $ (g $ x)`, meant to replace an outer pair of parens. Implemented as a
+// thin wrapper around parseThrush's previous body (parseThrushBase) so every
+// existing caller of parseThrush — the de facto "top of the expression
+// hierarchy" throughout this file — gets $ for free, binding looser than
+// everything parseThrush already handles (|, |?, |>, <|, and below).
+const parseThrush: C.Parser<Expression> = tokens => {
+	const leftResult = parseThrushBase(tokens);
+	if (!leftResult.success) return leftResult;
+
+	const opResult = C.operator('$')(leftResult.remaining);
+	if (!opResult.success) return leftResult;
+
+	// Right-associative: recurse into parseThrush (not parseThrushBase) so a
+	// chain of $ nests to the right instead of folding left.
+	const rightResult = parseThrush(opResult.remaining);
+	if (!rightResult.success) return rightResult;
+
+	const result: BinaryExpression = {
+		kind: 'binary',
+		operator: '$',
+		left: leftResult.value,
+		right: rightResult.value,
+		location: leftResult.value.location,
+	};
+	return { success: true, value: result, remaining: rightResult.remaining };
+};
 
 // Helper function to apply postfix operators to an expression
 // Parse type annotation with optional constraint: : Type [given Constraint]

--- a/src/typer/pattern-matching.ts
+++ b/src/typer/pattern-matching.ts
@@ -38,7 +38,10 @@ export const typeTypeDefinition = (
 
 	// Disallow shadowing built-in types and stdlib ADTs
 	if (isReservedTypeName(name)) {
-		throw new Error(`Shadowing built in type ${name}`);
+		throwTypeError(
+			location => createTypeError(`Shadowing built in type ${name}`, {}, location),
+			getExprLocation(expr)
+		);
 	}
 
 	// If stdlib and builtins are loaded (protected set is non-empty), enforce global no-shadowing
@@ -46,7 +49,10 @@ export const typeTypeDefinition = (
 	if (strictShadowing) {
 		// Disallow shadowing any existing type/constructor in current session
 		if (state.protectedTypeNames.has(name)) {
-			throw new Error(`Type shadowing is not allowed: ${name}`);
+			throwTypeError(
+				location => createTypeError(`Type shadowing is not allowed: ${name}`, {}, location),
+				getExprLocation(expr)
+			);
 		}
 		// Also prevent shadowing of any currently-bound uppercase identifier in environment (constructors/types)
 		for (const existingName of state.environment.keys()) {
@@ -54,14 +60,20 @@ export const typeTypeDefinition = (
 				existingName === name &&
 				existingName[0] === existingName[0].toUpperCase()
 			) {
-				throw new Error(`Type shadowing is not allowed: ${name}`);
+				throwTypeError(
+					location => createTypeError(`Type shadowing is not allowed: ${name}`, {}, location),
+					getExprLocation(expr)
+				);
 			}
 		}
 	}
 
 	// If ADT already exists in registry, always error (duplicate definition)
 	if (state.adtRegistry.has(name)) {
-		throw new Error(`Type already defined: ${name}`);
+		throwTypeError(
+			location => createTypeError(`Type already defined: ${name}`, {}, location),
+			getExprLocation(expr)
+		);
 	}
 
 	// Create stable type variables for the ADT's type parameters
@@ -240,7 +252,10 @@ export const typeMatch = (
 
 	// Type each case and ensure they all return the same type
 	if (expr.cases.length === 0) {
-		throw new Error('Match expression must have at least one case');
+		throwTypeError(
+			location => createTypeError('Match expression must have at least one case', {}, location),
+			getExprLocation(expr)
+		);
 	}
 
 	// Type first case to get result type
@@ -377,7 +392,10 @@ const typePattern = (
 				}
 
 				if (!foundAdt) {
-					throw new Error(`Unknown constructor: ${pattern.name}`);
+					throwTypeError(
+						location => createTypeError(`Unknown constructor: ${pattern.name}`, {}, location),
+						getExprLocation(pattern)
+					);
 				}
 
 				// Create the ADT type with fresh type variables for type parameters
@@ -395,29 +413,50 @@ const typePattern = (
 				// Unify the type variable with the ADT type
 				currentState = unify(expectedType, actualType, currentState, undefined);
 			} else if (!isTypeKind(expectedType, 'variant')) {
-				throw new Error(
-					`Pattern expects constructor but got ${typeToString(
-						expectedType,
-						state.substitution
-					)}`
+				throwTypeError(
+					location =>
+						createTypeError(
+							`Pattern expects constructor but got ${typeToString(
+								expectedType,
+								state.substitution
+							)}`,
+							{},
+							location
+						),
+					getExprLocation(pattern)
 				);
 			}
 
 			// Look up constructor in ADT registry
 			if (!isTypeKind(actualType, 'variant')) {
-				throw new Error(
-					`Internal error: actualType should be variant but got ${actualType.kind}`
+				throwTypeError(
+					location =>
+						createTypeError(
+							`Internal error: actualType should be variant but got ${actualType.kind}`,
+							{},
+							location
+						),
+					getExprLocation(pattern)
 				);
 			}
 			const adtInfo = state.adtRegistry.get(actualType.name);
 			if (!adtInfo) {
-				throw new Error(`Unknown ADT: ${actualType.name}`);
+				throwTypeError(
+					location => createTypeError(`Unknown ADT: ${actualType.name}`, {}, location),
+					getExprLocation(pattern)
+				);
 			}
 
 			const constructorArgs = adtInfo.constructors.get(pattern.name);
 			if (!constructorArgs) {
-				throw new Error(
-					`Unknown constructor: ${pattern.name} for ADT ${actualType.name}`
+				throwTypeError(
+					location =>
+						createTypeError(
+							`Unknown constructor: ${pattern.name} for ADT ${actualType.name}`,
+							{},
+							location
+						),
+					getExprLocation(pattern)
 				);
 			}
 
@@ -434,8 +473,14 @@ const typePattern = (
 
 			// Check argument count
 			if (pattern.args.length !== substitutedArgs.length) {
-				throw new Error(
-					`Constructor ${pattern.name} expects ${substitutedArgs.length} arguments but got ${pattern.args.length}`
+				throwTypeError(
+					location =>
+						createTypeError(
+							`Constructor ${pattern.name} expects ${substitutedArgs.length} arguments but got ${pattern.args.length}`,
+							{},
+							location
+						),
+					getExprLocation(pattern)
 				);
 			}
 
@@ -465,7 +510,10 @@ const typePattern = (
 			} else if (typeof pattern.value === 'string') {
 				literalType = stringType();
 			} else {
-				throw new Error(`Unsupported literal pattern: ${pattern.value}`);
+				throwTypeError(
+					location => createTypeError(`Unsupported literal pattern: ${pattern.value}`, {}, location),
+					getExprLocation(pattern)
+				);
 			}
 
 			const unifiedState = unify(
@@ -480,11 +528,17 @@ const typePattern = (
 		case 'tuple': {
 			// Validate expected type is tuple
 			if (!isTypeKind(expectedType, 'tuple') && !isTypeKind(expectedType, 'variable')) {
-				throw new Error(
-					`Pattern expects tuple but got ${typeToString(
-						expectedType,
-						state.substitution
-					)}`
+				throwTypeError(
+					location =>
+						createTypeError(
+							`Pattern expects tuple but got ${typeToString(
+								expectedType,
+								state.substitution
+							)}`,
+							{},
+							location
+						),
+					getExprLocation(pattern)
 				);
 			}
 
@@ -506,13 +560,22 @@ const typePattern = (
 			}
 
 			if (!isTypeKind(actualType, 'tuple')) {
-				throw new Error('Internal error: actualType should be tuple');
+				throwTypeError(
+					location => createTypeError('Internal error: actualType should be tuple', {}, location),
+					getExprLocation(pattern)
+				);
 			}
 
 			// Check element count
 			if (pattern.elements.length !== actualType.elements.length) {
-				throw new Error(
-					`Tuple pattern expects ${pattern.elements.length} elements but type has ${actualType.elements.length}`
+				throwTypeError(
+					location =>
+						createTypeError(
+							`Tuple pattern expects ${pattern.elements.length} elements but type has ${actualType.elements.length}`,
+							{},
+							location
+						),
+					getExprLocation(pattern)
 				);
 			}
 
@@ -537,11 +600,17 @@ const typePattern = (
 		case 'record': {
 			// Validate expected type is record or type variable
 			if (!isTypeKind(expectedType, 'record') && !isTypeKind(expectedType, 'variable')) {
-				throw new Error(
-					`Pattern expects record but got ${typeToString(
-						expectedType,
-						state.substitution
-					)}`
+				throwTypeError(
+					location =>
+						createTypeError(
+							`Pattern expects record but got ${typeToString(
+								expectedType,
+								state.substitution
+							)}`,
+							{},
+							location
+						),
+					getExprLocation(pattern)
 				);
 			}
 
@@ -563,7 +632,10 @@ const typePattern = (
 			}
 
 			if (!isTypeKind(actualType, 'record')) {
-				throw new Error('Internal error: actualType should be record');
+				throwTypeError(
+					location => createTypeError('Internal error: actualType should be record', {}, location),
+					getExprLocation(pattern)
+				);
 			}
 
 			// Type each field pattern
@@ -605,6 +677,14 @@ const typePattern = (
 		}
 
 		default:
-			throw new Error(`Unsupported pattern kind: ${(pattern as Pattern).kind}`);
+			throwTypeError(
+				location =>
+					createTypeError(
+						`Unsupported pattern kind: ${(pattern as Pattern).kind}`,
+						{},
+						location
+					),
+				getExprLocation(pattern as Pattern)
+			);
 	}
 };

--- a/test/features/operators/dollar_operator.test.ts
+++ b/test/features/operators/dollar_operator.test.ts
@@ -1,0 +1,45 @@
+import { test, expect } from 'bun:test';
+import { runCode } from '../../utils';
+
+// $ is low-precedence, right-associative function application — `f $ x` is
+// `f x`, meant to replace an outer pair of parens. Fully implemented in the
+// typer (handleDollar) and evaluator, and reachable via operator sectioning
+// ((`$`)), but had no parser rule turning plain infix `f $ x` into that
+// BinaryExpression at all — this suite is a regression test for that gap.
+
+test('applies a function to an argument', () => {
+	const result = runCode(`
+        add_one = fn x => x + 1;
+        add_one $ 5
+      `);
+	expect(result.finalValue).toEqual(6);
+});
+
+test('avoids nested parens for chained application', () => {
+	const result = runCode(`
+        map (fn x => x * 2) $ filter (fn x => x > 5) [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+      `);
+	const withParens = runCode(`
+        map (fn x => x * 2) (filter (fn x => x > 5) [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+      `);
+	expect(result.finalValue).toEqual(withParens.finalValue);
+});
+
+test('is right-associative: f $ g $ x is f (g x)', () => {
+	const result = runCode(`
+        add_one = fn x => x + 1;
+        double = fn x => x * 2;
+        add_one $ double $ 5
+      `);
+	expect(result.finalValue).toEqual(11);
+});
+
+test('binds looser than thrush/pipe operators', () => {
+	// `|` should bind tighter than `$`, so this is add_one $ (5 | double)
+	const result = runCode(`
+        add_one = fn x => x + 1;
+        double = fn x => x * 2;
+        add_one $ 5 | double
+      `);
+	expect(result.finalValue).toEqual(11);
+});


### PR DESCRIPTION
## Summary
- `src/typer/pattern-matching.ts`: every type error in this file threw a bare `new Error(...)`, bypassing the codebase's `throwTypeError`/`createTypeError`/`getExprLocation` convention — so unknown-constructor, arity-mismatch, non-exhaustive-match, and type-shadowing errors all silently reported line 1 regardless of where the real problem was. Swept all 17 call sites onto the real convention.
- `examples/demo.noo`: fixed a real constructor-arity bug (`None _ => 0` — `None` takes 0 args) found via the location fix above finally pointing at the right line; also uncommented a `$`-operator example that was blocked on the bug below.
- `src/parser/parser.ts`: `$` was fully implemented in the typer (`handleDollar`) and evaluator, and reachable via operator sectioning (`($)`), but had no grammar rule ever turning plain infix `f $ x` into that `BinaryExpression` — dead on arrival for its actual intended use. Added it as a new lowest-precedence, right-associative level wrapping `parseThrush`.
- `find_todos.noo`: eta-reduced a redundant lambda now that `scan_file` already returns `{}`.
- `docs-wip/POINT_FREE_MATCH_PLAN.md`: scoping notes for a related future feature (point-free `match`, i.e. `\case`-equivalent), not implemented here.

## Test plan
- [x] `bun run typecheck` / `bun run typecheck:test`
- [x] `AGENT=1 bun test` — 1317 pass / 0 fail (4 new regression tests for `$`, written red-then-green per TDD)
- [x] `node validate_examples.js` — exit 0
- [x] Manually verified `$` precedence/associativity and the pattern-matching location fix against real error cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TASnoHntaoTfJZpshTGnB