### PR TITLE
<PARKED> Implement point-free match_ (flipped match, per ADR 0001)

### DIFF
--- a/docs/internal/docs-wip/POINT_FREE_MATCH_PLAN.md
+++ b/docs/internal/docs-wip/POINT_FREE_MATCH_PLAN.md
@@ -1,12 +1,15 @@
 # Point-free `match` (Haskell `\case` equivalent)
 
-**Implemented.** `match (arms)` (scrutinee omitted) desugars at parse time to
-`fn __match_x => match __match_x (arms)`; see `parseMatchExpression` in
-`src/parser/parser.ts` and `test/features/pattern-matching/point_free_match.test.ts`
-(the ambiguity spike below and its adversarial cases are captured there as
-regression tests). Documented in `docs/language-reference.md` under "Pattern
-Matching and Exhaustiveness". The rest of this doc is kept as the design
-record for why the ordered-choice approach was judged safe to implement.
+**Implemented as `match_`.** `match_ (arms)` (scrutinee omitted, argument
+moved to last position) desugars at parse time to
+`fn __match_x => match __match_x (arms)`; see `parseMatchUnderscoreExpression`
+in `src/parser/parser.ts`, `match_` in the keyword list in
+`src/lexer/lexer.ts`, and
+`test/features/pattern-matching/point_free_match.test.ts`. Documented in
+`docs/language-reference.md` under "Pattern Matching and Exhaustiveness".
+`match_` fits the trailing-underscore "flipped form" naming convention —
+see `docs/internal/adrs/0001-trailing-underscore-flip.md` for the full
+argument; this doc covers only the `match`-specific history.
 
 Raised while looking at `find_todos.noo`:
 `fn foo => match (foo) (...)` can't be eta-reduced to point-free form, because
@@ -21,72 +24,30 @@ Exhaustiveness checking currently runs against the scrutinee's known type at
 the match site; making `match` a first-class value means deferring that
 check to wherever the resulting function gets applied, which could be a
 different module entirely. That's a real typer redesign, and lands squarely
-in the hazard CLAUDE.md already calls out: constraint/inference code goes
+in the hazard AGENTS.md already calls out: constraint/inference code goes
 green and wrong at the same time. Not worth it for a stylistic win.
 
-## The actual fix: syntax sugar, not semantics
+Given that, the fix has to be syntax sugar, not semantics: a pure
+parse-time desugaring to a synthetic `FunctionExpression` wrapping an
+ordinary `MatchExpression`. `match` itself, its typing, and its
+exhaustiveness checking stay untouched either way — the only open question
+was what the new surface syntax should look like.
 
-Same category as operator sectioning (#133, `src/parser/parser.ts` around
-line 336, `parseOperatorSection`): a pure parse-time desugaring, no typer
-changes. That precedent synthesizes a lambda with fresh params
-(`__section_a`, `__section_b`) wrapping a `BinaryExpression` that references
-them.
+## First attempt: `match (arms)`, reusing `match`'s own prefix — reverted
 
-Same shape here: `match (arms)` with the scrutinee omitted desugars to
-`fn __match_x => match __match_x (arms)` — a synthetic `FunctionExpression`
-wrapping an ordinary `MatchExpression`. `match` itself, its typing, and its
-exhaustiveness checking are all untouched; only the parser changes.
+The first implementation spelled point-free match as `match (arms)`,
+reusing the `match` keyword itself and disambiguating from
+`match (scrutinee) (arms)` by trying to parse the arms block first and
+backtracking to the scrutinee form on failure (ordered-choice parsing, the
+same technique `C.choice`/`C.choice2` already use elsewhere in
+`src/parser/parser.ts`).
 
-Current grammar, for reference (`src/parser/parser.ts:1855-1878`,
-`parseMatchExpression`): `match` keyword, then a required scrutinee via
-`parseThrush`, then `(`, semicolon-separated `pattern => expr` cases, `)`.
-The scrutinee is not optional today — this is the one production that needs
-a new branch.
-
-## The real risk: `match (` is ambiguous
-
-`match (foo) (arms)` — a parenthesized scrutinee — and the proposed
-`match (arms)` — point-free, no scrutinee — both start with `match (`. The
-parser can't tell which it's looking at from the `(` alone; it has to look
-inside.
-
-Proposed disambiguation: after `match`, attempt to parse
-`( sepBy(pattern => expr, ;) )` first (the arms form). If that succeeds,
-it's point-free. If it fails, backtrack and parse the existing
-`scrutinee (arms)` form. This is ordinary PEG-style ordered-choice
-backtracking, consistent with how this parser already uses `C.choice`/
-`C.lazy` elsewhere — not a new parsing technique.
-
-Where this could still collide: a parenthesized scrutinee whose first
-token could also start a pattern. Patterns start with constructor names,
-literals, identifiers, wildcards, or destructuring syntax — normal
-expressions mostly don't start the same way `pattern =>` does, since `=>`
-isn't a general infix operator outside `fn`/`match`.
-
-## Spike result: no real collision
-
-Confirmed by inspecting the grammar (`parsePattern`, `parseMatchCase` in
-`src/parser/parser.ts`) and by constructing the adversarial cases named
-above:
-
-- Every match case requires a literal `=>` immediately after a
-  syntactically valid pattern (`parseMatchCase` is `parsePattern,
-  operator('=>'), expr`).
-- No valid Noolang scrutinee expression can produce a bare top-level `=>`.
-  Lambdas require the `fn` keyword first, and the lexer tokenizes `fn` as
-  `KEYWORD`, never `IDENTIFIER` — so `fn` can never itself be parsed as a
-  pattern (patterns only start from identifiers, literals, `_`, `{`, or a
-  constructor name).
-- Therefore a parenthesized scrutinee can never be mistaken for an arms
-  block: either the first token inside the parens isn't a valid pattern
-  start at all (the `fn` case), or it parses as a pattern but the next
-  token isn't `=>` (the bare-identifier/constructor case) — either way the
-  arms-only parse attempt fails and backtracks cleanly to the scrutinee
-  form.
-
-Verified concretely, both by direct CLI probes against the pre-implementation
-grammar and as permanent regression tests post-implementation
-(`test/features/pattern-matching/point_free_match.test.ts`):
+**The parser could tell the two forms apart soundly** — this was spiked
+before implementation, not assumed. `parseMatchCase` requires a literal
+`=>` immediately after a syntactically valid pattern, and no valid Noolang
+scrutinee expression can produce a bare top-level `=>` (lambdas need the
+`fn` keyword first, and the lexer tokenizes `fn` as `KEYWORD`, never
+`IDENTIFIER`, so `fn` can never itself be parsed as a pattern). Concretely:
 
 - `match (foo) (Some x => x; None => 0)` (bare-identifier scrutinee) —
   pattern `foo` parses, next token is `)` not `=>`, arms-attempt fails,
@@ -95,24 +56,46 @@ grammar and as permanent regression tests post-implementation
   scrutinee) — `fn` isn't a valid pattern-start token, arms-attempt fails
   immediately, falls back correctly.
 - `--types` on both the point-free form and its pointful
-  `fn foo => match (foo) (...)` equivalent infer the identical type
-  (`Option Float -> Float`), confirming the desugaring is faithful.
+  `fn foo => match (foo) (...)` equivalent inferred the identical type,
+  confirming the desugaring was faithful.
+
+**This was reverted anyway.** Parser-soundness isn't the same bar as
+reader-clarity: `match (` meant two different things depending on what
+followed, resolvable only by lookahead — correct for the parser, opaque for
+a human skimming the source. Both OCaml (`function arms`, a keyword
+distinct from `fun`) and Haskell (`\case arms`, LambdaCase) solve the
+identical problem by paying for a second, lexically distinct token instead
+of overloading the first construct's own prefix — see the ADR for the full
+argument. `fn match (arms)` (putting the ambiguity in `fn`'s parameter list
+instead) was considered and rejected for the same reason, just relocated.
+
+## What shipped: `match_`, a distinct keyword
+
+`match_` is lexed as its own `KEYWORD` token, alongside `match`, in
+`src/lexer/lexer.ts` — not a mode switch inside `parseMatchExpression` on
+the `match` token. `parseMatchUnderscoreExpression` in
+`src/parser/parser.ts` is unconditionally point-free: no backtracking, no
+shared prefix, no ambiguity to resolve at any level (parser or reader).
+`parseMatchExpression` itself is back to its original simple form —
+`match` keyword, scrutinee, arms block, no branching.
 
 ## Scope (completed)
 
-1. ~~Spike the ambiguity~~ — done above, no collision found.
-2. Parser: new branch in `parseMatchExpression`
-   (`src/parser/parser.ts`), desugaring to a `FunctionExpression` per the
-   operator-sectioning precedent. Implemented via ordered-choice: try
-   `parseMatchArms` (the `( pattern => expr ; ... )` block) right after the
-   `match` keyword; on success, wrap it as
-   `fn __match_x => match __match_x (arms)`; on failure, backtrack to
-   parsing a scrutinee followed by the arms block.
+1. Lexer: added `match_` to the keyword list (`src/lexer/lexer.ts`).
+   Confirmed safe — the lexer already reads identifiers (including a
+   trailing `_`) as one token before checking the keyword list, so
+   `match_` and `match` were never at risk of colliding token-wise.
+2. Parser: `parseMatchUnderscoreExpression` (`src/parser/parser.ts`),
+   wired into every call site that previously only listed
+   `parseMatchExpression` (lambda bodies, nested match-case expressions,
+   `where`-clause main expressions, the fast-dispatch keyword switch in
+   `parseSequenceTerm`).
 3. `docs/language-reference.md` — "Pattern Matching and Exhaustiveness"
-   section now documents the point-free form alongside the existing one.
-4. Regression tests: `test/features/pattern-matching/point_free_match.test.ts`,
-   covering the point-free form itself plus both adversarial collision
-   cases from the spike.
+   documents `match_` alongside the existing two-argument form.
+4. Regression tests: `test/features/pattern-matching/point_free_match.test.ts`
+   — the point-free form itself, inline application, higher-order use,
+   wildcard catch-all, nesting inside an ordinary `match` case, and
+   eta-equivalence (same result and inferred type) against the pointful
+   `fn foo => match (foo) (...)` wrapper.
 
-No stdlib or typer changes were needed — confirmed by the identical
-`--types` output above.
+No stdlib or typer changes were needed.

--- a/docs/internal/docs-wip/POINT_FREE_MATCH_PLAN.md
+++ b/docs/internal/docs-wip/POINT_FREE_MATCH_PLAN.md
@@ -1,6 +1,14 @@
 # Point-free `match` (Haskell `\case` equivalent)
 
-Scoping note, not yet implemented. Raised while looking at `find_todos.noo`:
+**Implemented.** `match (arms)` (scrutinee omitted) desugars at parse time to
+`fn __match_x => match __match_x (arms)`; see `parseMatchExpression` in
+`src/parser/parser.ts` and `test/features/pattern-matching/point_free_match.test.ts`
+(the ambiguity spike below and its adversarial cases are captured there as
+regression tests). Documented in `docs/language-reference.md` under "Pattern
+Matching and Exhaustiveness". The rest of this doc is kept as the design
+record for why the ordered-choice approach was judged safe to implement.
+
+Raised while looking at `find_todos.noo`:
 `fn foo => match (foo) (...)` can't be eta-reduced to point-free form, because
 `match` is special syntax (`match <scrutinee> (<arms>)`), not a curried
 function value — there's nothing to eta-reduce *to*.
@@ -53,24 +61,58 @@ Where this could still collide: a parenthesized scrutinee whose first
 token could also start a pattern. Patterns start with constructor names,
 literals, identifiers, wildcards, or destructuring syntax — normal
 expressions mostly don't start the same way `pattern =>` does, since `=>`
-isn't a general infix operator outside `fn`/`match`. No concrete collision
-found by inspection, but this needs an actual spike — write both forms
-side by side, including deliberately adversarial cases (e.g. a scrutinee
-that's itself a bare identifier or a parenthesized single-arg lambda) —
-before implementation, not asserted confidently here.
+isn't a general infix operator outside `fn`/`match`.
 
-## Scope if this goes ahead
+## Spike result: no real collision
 
-1. Spike the ambiguity above first — if a real collision turns up, this
-   whole approach needs rethinking (e.g. a different point-free spelling
-   that doesn't share `match (`'s prefix).
-2. Parser: new branch in `parseMatchExpression`, desugaring to a
-   `FunctionExpression` per the operator-sectioning precedent.
+Confirmed by inspecting the grammar (`parsePattern`, `parseMatchCase` in
+`src/parser/parser.ts`) and by constructing the adversarial cases named
+above:
+
+- Every match case requires a literal `=>` immediately after a
+  syntactically valid pattern (`parseMatchCase` is `parsePattern,
+  operator('=>'), expr`).
+- No valid Noolang scrutinee expression can produce a bare top-level `=>`.
+  Lambdas require the `fn` keyword first, and the lexer tokenizes `fn` as
+  `KEYWORD`, never `IDENTIFIER` — so `fn` can never itself be parsed as a
+  pattern (patterns only start from identifiers, literals, `_`, `{`, or a
+  constructor name).
+- Therefore a parenthesized scrutinee can never be mistaken for an arms
+  block: either the first token inside the parens isn't a valid pattern
+  start at all (the `fn` case), or it parses as a pattern but the next
+  token isn't `=>` (the bare-identifier/constructor case) — either way the
+  arms-only parse attempt fails and backtracks cleanly to the scrutinee
+  form.
+
+Verified concretely, both by direct CLI probes against the pre-implementation
+grammar and as permanent regression tests post-implementation
+(`test/features/pattern-matching/point_free_match.test.ts`):
+
+- `match (foo) (Some x => x; None => 0)` (bare-identifier scrutinee) —
+  pattern `foo` parses, next token is `)` not `=>`, arms-attempt fails,
+  falls back correctly.
+- `match (fn x => x) (_ => "matched")` (parenthesized single-arg lambda
+  scrutinee) — `fn` isn't a valid pattern-start token, arms-attempt fails
+  immediately, falls back correctly.
+- `--types` on both the point-free form and its pointful
+  `fn foo => match (foo) (...)` equivalent infer the identical type
+  (`Option Float -> Float`), confirming the desugaring is faithful.
+
+## Scope (completed)
+
+1. ~~Spike the ambiguity~~ — done above, no collision found.
+2. Parser: new branch in `parseMatchExpression`
+   (`src/parser/parser.ts`), desugaring to a `FunctionExpression` per the
+   operator-sectioning precedent. Implemented via ordered-choice: try
+   `parseMatchArms` (the `( pattern => expr ; ... )` block) right after the
+   `match` keyword; on success, wrap it as
+   `fn __match_x => match __match_x (arms)`; on failure, backtrack to
+   parsing a scrutinee followed by the arms block.
 3. `docs/language-reference.md` — "Pattern Matching and Exhaustiveness"
-   section (line ~504) needs the new form documented alongside the
-   existing one.
-4. Regression tests mirroring `operator-sectioning`'s test file, plus a
-   case exercising the ambiguity spike found in step 1.
+   section now documents the point-free form alongside the existing one.
+4. Regression tests: `test/features/pattern-matching/point_free_match.test.ts`,
+   covering the point-free form itself plus both adversarial collision
+   cases from the spike.
 
-No stdlib or typer changes anticipated — confirm that stays true once the
-spike is done.
+No stdlib or typer changes were needed — confirmed by the identical
+`--types` output above.

--- a/docs/language-reference.md
+++ b/docs/language-reference.md
@@ -536,6 +536,35 @@ match (Some 1) (Some x => x)
 A bare variable catch-all also works: `other => ...` matches anything not
 already covered and binds the value.
 
+#### Point-free `match`
+
+Omitting the scrutinee — `match (Pattern => branch; ...)` — desugars at
+parse time to `fn x => match x (Pattern => branch; ...)`. This lets a
+`match` used as a plain lambda body eta-reduce to point-free form, the same
+way operator sectioning (`(+)`) avoids writing out `fn a b => a + b`.
+
+```noolang
+# Point-free: no scrutinee, works directly as a function value
+classify = match (
+    Some x => "got " + show x;
+    None => "nothing"
+);
+classify (Some 42.0)
+```
+
+Because `match (` is ambiguous between a parenthesized scrutinee and the
+point-free form's arms block, the parser tries the arms form first and
+falls back to parsing a scrutinee if that fails. This is safe: every arm
+requires a literal `=>` right after a pattern, and no ordinary scrutinee
+expression can produce a bare `=>` (lambdas require `fn` first), so a real
+scrutinee — even a parenthesized one — never gets misread as arms.
+
+```noolang
+# Parenthesized scrutinee still works normally
+foo = Some 7.0;
+match (foo) (Some x => x; None => 0.0)
+```
+
 ### Destructuring Bindings
 
 Record destructuring binds a **subset** of fields — extra fields in the record

--- a/docs/language-reference.md
+++ b/docs/language-reference.md
@@ -536,31 +536,36 @@ match (Some 1) (Some x => x)
 A bare variable catch-all also works: `other => ...` matches anything not
 already covered and binds the value.
 
-#### Point-free `match`
+#### Point-free `match_`
 
-Omitting the scrutinee — `match (Pattern => branch; ...)` — desugars at
-parse time to `fn x => match x (Pattern => branch; ...)`. This lets a
-`match` used as a plain lambda body eta-reduce to point-free form, the same
-way operator sectioning (`(+)`) avoids writing out `fn a b => a + b`.
+`match_ (Pattern => branch; ...)` — the scrutinee omitted, using the
+dedicated `match_` keyword — desugars at parse time to
+`fn x => match x (Pattern => branch; ...)`. This lets a `match` used as a
+plain lambda body eta-reduce to point-free form, the same way operator
+sectioning (`(+)`) avoids writing out `fn a b => a + b`.
+
+`match_` follows a general naming convention: a trailing underscore names
+the "flipped" form of something — the first argument moves to last
+position, as with the `flip` combinator. `match` is special parser syntax
+rather than a bound value, so it can't be flipped with an ordinary
+function like `flip`; it gets its own keyword instead.
 
 ```noolang
 # Point-free: no scrutinee, works directly as a function value
-classify = match (
+classify = match_ (
     Some x => "got " + show x;
     None => "nothing"
 );
 classify (Some 42.0)
 ```
 
-Because `match (` is ambiguous between a parenthesized scrutinee and the
-point-free form's arms block, the parser tries the arms form first and
-falls back to parsing a scrutinee if that fails. This is safe: every arm
-requires a literal `=>` right after a pattern, and no ordinary scrutinee
-expression can produce a bare `=>` (lambdas require `fn` first), so a real
-scrutinee — even a parenthesized one — never gets misread as arms.
+`match_` is a distinct keyword from `match`, tokenized separately by the
+lexer — there's no shared prefix to disambiguate, so a parenthesized
+scrutinee after plain `match` is never at risk of being misread as a
+`match_` arms block:
 
 ```noolang
-# Parenthesized scrutinee still works normally
+# match with a parenthesized scrutinee is unaffected by match_
 foo = Some 7.0;
 match (foo) (Some x => x; None => 0.0)
 ```

--- a/src/lexer/lexer.ts
+++ b/src/lexer/lexer.ts
@@ -186,6 +186,7 @@ export class Lexer {
 			'variant',
 			'type',
 			'match',
+			'match_',
 			'with',
 			'given',
 			'is',

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -450,6 +450,7 @@ const parseLambdaBody: C.Parser<Expression> = tokens => {
 	// Handle complex expressions that start with keywords
 	const complexResult = C.choice(
 		parseMatchExpression,
+		parseMatchUnderscoreExpression,
 		parseTypeDefinition,
 		parseUserDefinedType,
 		parseConstraintDefinition,
@@ -1767,16 +1768,6 @@ const parseTupleOrRecordPattern: C.Parser<Pattern> = C.map(
 	}
 );
 
-// INVARIANT (relied on by parseMatchExpression's point-free/scrutinee
-// disambiguation below): no alternative here may start with the `fn`
-// keyword, or otherwise accept a token sequence that a normal expression
-// can also start with immediately followed by `=>`. parseMatchExpression
-// tells `match (arms)` (point-free) apart from `match (scrutinee) (arms)`
-// by trying to parse arms first, which only stays sound because a
-// parenthesized scrutinee can never itself look like `pattern => expr`. If
-// you add a pattern form here (e.g. guards, or-patterns) that could make a
-// scrutinee-shaped token sequence parse as a pattern followed by `=>`,
-// re-check that disambiguation.
 const parsePattern: C.Parser<Pattern> = C.choice(
 	// Wildcard pattern: _
 	C.map(
@@ -1870,8 +1861,9 @@ const parsePattern: C.Parser<Pattern> = C.choice(
 
 // --- Match Case Expression Parser ---
 // This parser supports expressions in match cases, including nested match expressions
-const parseMatchCaseExpression: C.Parser<Expression> = C.choice3(
+const parseMatchCaseExpression: C.Parser<Expression> = C.choice(
 	C.lazy(() => parseMatchExpression), // Support nested match expressions
+	C.lazy(() => parseMatchUnderscoreExpression), // Support nested point-free match_
 	C.lazy(() => parseIfExpression), // Support if expressions
 	C.lazy(() => parseExprWithType) // Support all other expressions including type annotations
 );
@@ -1912,77 +1904,52 @@ const buildMatch = (
 ): MatchExpression => ({ kind: 'match', expression, cases, location });
 
 // --- Match Expression ---
-// Two surface forms, both starting with the `match (` prefix:
-//   match <scrutinee> (arms)   -- the original form
-//   match (arms)                -- point-free: `fn x => match x (arms)`,
-//                                  letting `fn foo => match (foo) (...)` eta-reduce
-// The parser can't tell which from the leading `(` alone, so it uses
-// C.choice2's ordered-choice backtracking: try the arms-only form first,
-// and only if that fails, fall back to parsing a scrutinee followed by the
-// arms block. Routing through choice2 (rather than a hand-rolled if/else)
-// matters beyond consistency: choice2 keeps whichever branch's error made
-// furthest progress through the tokens, so a typo inside a valid arms block
-// (e.g. `match (Some x => x +++ 1; None => 0)`) still reports the real
-// parse error from the point-free attempt instead of the generic failure
-// from the scrutinee-form fallback.
+const parseMatchExpression: C.Parser<Expression> = C.map(
+	C.seq(C.keyword('match'), C.lazy(() => parseThrush), parseMatchArms),
+	([match, expression, { cases, close }]): Expression =>
+		buildMatch(
+			expression,
+			cases,
+			createLocation(match.location.start, close.location.end)
+		)
+);
+
+// --- Point-free Match Expression: match_ (arms) ---
+// `match_` (see docs/internal/adrs/0001-trailing-underscore-flip.md) is the
+// "flipped" form of `match`: the scrutinee argument moves to last position,
+// i.e. `match_ (arms)` is sugar for `fn x => match x (arms)`. It lets
+// `fn foo => match (foo) (arms)` eta-reduce to `match_ (arms)`.
 //
-// This disambiguation is safe because every match case requires a literal
-// `=>` immediately after a syntactically valid pattern, and no valid
-// Noolang scrutinee expression can produce a bare top-level `=>` — lambdas
-// require the `fn` keyword first, and `fn` is lexed as KEYWORD, not
-// IDENTIFIER, so it can never itself be parsed as a pattern (see the
-// invariant note on parsePattern/parseMatchCase above). A parenthesized
-// scrutinee therefore can never be mistaken for an arms block: either the
-// first token inside the parens isn't a valid pattern start at all (e.g.
-// `fn`), or it parses as a pattern but isn't followed by `=>` (e.g. a bare
-// identifier or constructor scrutinee), and either way the arms-only
-// attempt fails and backtracks cleanly. See
-// docs/internal/docs-wip/POINT_FREE_MATCH_PLAN.md for the spike that
-// established this before implementation, including the adversarial cases
-// (bare-identifier scrutinee, parenthesized single-arg lambda scrutinee)
-// exercised in test/features/pattern-matching/point_free_match.test.ts.
-const parseMatchExpression: C.Parser<Expression> = tokens => {
-	const matchResult = C.keyword('match')(tokens);
-	if (!matchResult.success) return matchResult;
-	const match = matchResult.value;
-
-	const parsePointFree: C.Parser<Expression> = C.map(
-		parseMatchArms,
-		({ cases, close }): Expression => {
-			const location = createLocation(
-				match.location.start,
-				close.location.end
-			);
-			const scrutineeVar: Expression = {
-				kind: 'variable',
-				name: '__match_x',
-				location,
-			};
-			const fn: FunctionExpression = {
-				kind: 'function',
-				params: ['__match_x'],
-				body: buildMatch(scrutineeVar, cases, location),
-				location,
-			};
-			return fn;
-		}
-	);
-
-	const parseWithScrutinee: C.Parser<Expression> = C.map(
-		C.seq(
-			C.lazy(() => parseThrush), // Use a simpler expression parser to avoid circular dependency
-			parseMatchArms
-		),
-		([expression, { cases, close }]): Expression =>
-			buildMatch(
-				expression,
-				cases,
-				createLocation(match.location.start, close.location.end)
-			)
-	);
-
-	return C.choice2(parsePointFree, parseWithScrutinee)(matchResult.remaining);
-};
+// This used to be spelled `match (arms)` — reusing `match`'s own `(`
+// prefix and disambiguating from `match (scrutinee) (arms)` via
+// parser backtracking. The parser could tell the two apart soundly, but a
+// human reader couldn't without the same lookahead, so that approach was
+// dropped in favor of a lexically distinct keyword (`match_`, tokenized
+// separately from `match` in src/lexer/lexer.ts) — the same fix OCaml
+// (`function` vs `fun`) and Haskell (`\case` / LambdaCase) use for the
+// identical problem. No backtracking needed: `match_` and `match` are
+// simply different tokens from the lexer onward.
+const parseMatchUnderscoreExpression: C.Parser<Expression> = C.map(
+	C.seq(C.keyword('match_'), parseMatchArms),
+	([matchUnderscore, { cases, close }]): Expression => {
+		const location = createLocation(
+			matchUnderscore.location.start,
+			close.location.end
+		);
+		const scrutineeVar: Expression = {
+			kind: 'variable',
+			name: '__match_x',
+			location,
+		};
+		const fn: FunctionExpression = {
+			kind: 'function',
+			params: ['__match_x'],
+			body: buildMatch(scrutineeVar, cases, location),
+			location,
+		};
+		return fn;
+	}
+);
 
 // --- Where Expression ---
 const parseWhereExpression: C.Parser<WhereExpression> = C.map(
@@ -2039,6 +2006,8 @@ const parseSequenceTerm: C.Parser<Expression> = tokens => {
 					return parseUserDefinedType(tokens);
 				case 'match':
 					return parseMatchExpression(tokens);
+				case 'match_':
+					return parseMatchUnderscoreExpression(tokens);
 				case 'import':
 					return parseImportExpression(tokens);
 				case 'if':
@@ -2117,6 +2086,7 @@ const parseIfExpression = C.map(
 const parseWhereMainExpression: C.Parser<Expression> = C.choice(
 	// Parse keyword-based expressions first to avoid identifier conflicts
 	parseMatchExpression, // ADT pattern matching (starts with "match")
+	parseMatchUnderscoreExpression, // point-free match (starts with "match_")
 	parseTypeDefinition, // ADT variant definitions (starts with "variant")
 	parseUserDefinedType, // User-defined types (starts with "type")
 	parseConstraintDefinition, // constraint definitions (starts with "constraint")

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -1767,6 +1767,16 @@ const parseTupleOrRecordPattern: C.Parser<Pattern> = C.map(
 	}
 );
 
+// INVARIANT (relied on by parseMatchExpression's point-free/scrutinee
+// disambiguation below): no alternative here may start with the `fn`
+// keyword, or otherwise accept a token sequence that a normal expression
+// can also start with immediately followed by `=>`. parseMatchExpression
+// tells `match (arms)` (point-free) apart from `match (scrutinee) (arms)`
+// by trying to parse arms first, which only stays sound because a
+// parenthesized scrutinee can never itself look like `pattern => expr`. If
+// you add a pattern form here (e.g. guards, or-patterns) that could make a
+// scrutinee-shaped token sequence parse as a pattern followed by `=>`,
+// re-check that disambiguation.
 const parsePattern: C.Parser<Pattern> = C.choice(
 	// Wildcard pattern: _
 	C.map(
@@ -1883,7 +1893,6 @@ const parseMatchCase: C.Parser<MatchCase> = C.map(
 // --- Match Arms (the "( pattern => expr ; ... )" block shared by both forms) ---
 const parseMatchArms: C.Parser<{
 	cases: MatchCase[];
-	open: Token;
 	close: Token;
 }> = C.map(
 	C.seq(
@@ -1893,8 +1902,14 @@ const parseMatchArms: C.Parser<{
 		C.many(C.punctuation(';')),
 		C.punctuation(')')
 	),
-	([open, cases, _trailingSemicolons, close]) => ({ cases, open, close })
+	([_open, cases, _trailingSemicolons, close]) => ({ cases, close })
 );
+
+const buildMatch = (
+	expression: Expression,
+	cases: MatchCase[],
+	location: ReturnType<typeof createLocation>
+): MatchExpression => ({ kind: 'match', expression, cases, location });
 
 // --- Match Expression ---
 // Two surface forms, both starting with the `match (` prefix:
@@ -1902,68 +1917,71 @@ const parseMatchArms: C.Parser<{
 //   match (arms)                -- point-free: `fn x => match x (arms)`,
 //                                  letting `fn foo => match (foo) (...)` eta-reduce
 // The parser can't tell which from the leading `(` alone, so it uses
-// ordered-choice backtracking (same technique as C.choice elsewhere in this
-// file): try the arms-only form first, and only if that fails, fall back to
-// parsing a scrutinee followed by the arms block.
+// C.choice2's ordered-choice backtracking: try the arms-only form first,
+// and only if that fails, fall back to parsing a scrutinee followed by the
+// arms block. Routing through choice2 (rather than a hand-rolled if/else)
+// matters beyond consistency: choice2 keeps whichever branch's error made
+// furthest progress through the tokens, so a typo inside a valid arms block
+// (e.g. `match (Some x => x +++ 1; None => 0)`) still reports the real
+// parse error from the point-free attempt instead of the generic failure
+// from the scrutinee-form fallback.
 //
-// This is safe because every match case requires a literal `=>` immediately
-// after a syntactically valid pattern, and no valid Noolang scrutinee
-// expression can produce a bare top-level `=>` — lambdas require the `fn`
-// keyword first, and `fn` is lexed as KEYWORD, not IDENTIFIER, so it can
-// never itself be parsed as a pattern. A parenthesized scrutinee therefore
-// can never be mistaken for an arms block: either the first token inside the
-// parens isn't a valid pattern start at all (e.g. `fn`), or it parses as a
-// pattern but isn't followed by `=>` (e.g. a bare identifier or constructor
-// scrutinee), and either way the arms-only attempt fails and backtracks
-// cleanly. See docs/internal/docs-wip/POINT_FREE_MATCH_PLAN.md for the spike
-// that established this before implementation, including the adversarial
-// cases (bare-identifier scrutinee, parenthesized single-arg lambda
-// scrutinee) exercised in test/features/pattern-matching/point_free_match.test.ts.
+// This disambiguation is safe because every match case requires a literal
+// `=>` immediately after a syntactically valid pattern, and no valid
+// Noolang scrutinee expression can produce a bare top-level `=>` — lambdas
+// require the `fn` keyword first, and `fn` is lexed as KEYWORD, not
+// IDENTIFIER, so it can never itself be parsed as a pattern (see the
+// invariant note on parsePattern/parseMatchCase above). A parenthesized
+// scrutinee therefore can never be mistaken for an arms block: either the
+// first token inside the parens isn't a valid pattern start at all (e.g.
+// `fn`), or it parses as a pattern but isn't followed by `=>` (e.g. a bare
+// identifier or constructor scrutinee), and either way the arms-only
+// attempt fails and backtracks cleanly. See
+// docs/internal/docs-wip/POINT_FREE_MATCH_PLAN.md for the spike that
+// established this before implementation, including the adversarial cases
+// (bare-identifier scrutinee, parenthesized single-arg lambda scrutinee)
+// exercised in test/features/pattern-matching/point_free_match.test.ts.
 const parseMatchExpression: C.Parser<Expression> = tokens => {
 	const matchResult = C.keyword('match')(tokens);
 	if (!matchResult.success) return matchResult;
 	const match = matchResult.value;
 
-	const pointFreeResult = parseMatchArms(matchResult.remaining);
-	if (pointFreeResult.success) {
-		const { cases, close } = pointFreeResult.value;
-		const location = createLocation(match.location.start, close.location.end);
-		const scrutineeVar: Expression = {
-			kind: 'variable',
-			name: '__match_x',
-			location,
-		};
-		const matchExpr: MatchExpression = {
-			kind: 'match',
-			expression: scrutineeVar,
-			cases,
-			location,
-		};
-		const fn: FunctionExpression = {
-			kind: 'function',
-			params: ['__match_x'],
-			body: matchExpr,
-			location,
-		};
-		return {
-			success: true,
-			value: fn,
-			remaining: pointFreeResult.remaining,
-		};
-	}
+	const parsePointFree: C.Parser<Expression> = C.map(
+		parseMatchArms,
+		({ cases, close }): Expression => {
+			const location = createLocation(
+				match.location.start,
+				close.location.end
+			);
+			const scrutineeVar: Expression = {
+				kind: 'variable',
+				name: '__match_x',
+				location,
+			};
+			const fn: FunctionExpression = {
+				kind: 'function',
+				params: ['__match_x'],
+				body: buildMatch(scrutineeVar, cases, location),
+				location,
+			};
+			return fn;
+		}
+	);
 
-	return C.map(
+	const parseWithScrutinee: C.Parser<Expression> = C.map(
 		C.seq(
 			C.lazy(() => parseThrush), // Use a simpler expression parser to avoid circular dependency
 			parseMatchArms
 		),
-		([expression, { cases, close }]): Expression => ({
-			kind: 'match',
-			expression,
-			cases,
-			location: createLocation(match.location.start, close.location.end),
-		})
-	)(matchResult.remaining);
+		([expression, { cases, close }]): Expression =>
+			buildMatch(
+				expression,
+				cases,
+				createLocation(match.location.start, close.location.end)
+			)
+	);
+
+	return C.choice2(parsePointFree, parseWithScrutinee)(matchResult.remaining);
 };
 
 // --- Where Expression ---

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -1880,31 +1880,91 @@ const parseMatchCase: C.Parser<MatchCase> = C.map(
 	})
 );
 
-// --- Match Expression ---
-const parseMatchExpression: C.Parser<MatchExpression> = C.map(
+// --- Match Arms (the "( pattern => expr ; ... )" block shared by both forms) ---
+const parseMatchArms: C.Parser<{
+	cases: MatchCase[];
+	open: Token;
+	close: Token;
+}> = C.map(
 	C.seq(
-		C.keyword('match'),
-		C.lazy(() => parseThrush), // Use a simpler expression parser to avoid circular dependency
 		C.punctuation('('),
 		C.sepBy(parseMatchCase, C.punctuation(';')),
 		// Allow and ignore trailing semicolons after the last case
 		C.many(C.punctuation(';')),
 		C.punctuation(')')
 	),
-	([
-		match,
-		expression,
-		_openParen,
-		cases,
-		_trailingSemicolons,
-		closeParen,
-	]): MatchExpression => ({
-		kind: 'match',
-		expression,
-		cases,
-		location: createLocation(match.location.start, closeParen.location.end),
-	})
+	([open, cases, _trailingSemicolons, close]) => ({ cases, open, close })
 );
+
+// --- Match Expression ---
+// Two surface forms, both starting with the `match (` prefix:
+//   match <scrutinee> (arms)   -- the original form
+//   match (arms)                -- point-free: `fn x => match x (arms)`,
+//                                  letting `fn foo => match (foo) (...)` eta-reduce
+// The parser can't tell which from the leading `(` alone, so it uses
+// ordered-choice backtracking (same technique as C.choice elsewhere in this
+// file): try the arms-only form first, and only if that fails, fall back to
+// parsing a scrutinee followed by the arms block.
+//
+// This is safe because every match case requires a literal `=>` immediately
+// after a syntactically valid pattern, and no valid Noolang scrutinee
+// expression can produce a bare top-level `=>` — lambdas require the `fn`
+// keyword first, and `fn` is lexed as KEYWORD, not IDENTIFIER, so it can
+// never itself be parsed as a pattern. A parenthesized scrutinee therefore
+// can never be mistaken for an arms block: either the first token inside the
+// parens isn't a valid pattern start at all (e.g. `fn`), or it parses as a
+// pattern but isn't followed by `=>` (e.g. a bare identifier or constructor
+// scrutinee), and either way the arms-only attempt fails and backtracks
+// cleanly. See docs/internal/docs-wip/POINT_FREE_MATCH_PLAN.md for the spike
+// that established this before implementation, including the adversarial
+// cases (bare-identifier scrutinee, parenthesized single-arg lambda
+// scrutinee) exercised in test/features/pattern-matching/point_free_match.test.ts.
+const parseMatchExpression: C.Parser<Expression> = tokens => {
+	const matchResult = C.keyword('match')(tokens);
+	if (!matchResult.success) return matchResult;
+	const match = matchResult.value;
+
+	const pointFreeResult = parseMatchArms(matchResult.remaining);
+	if (pointFreeResult.success) {
+		const { cases, close } = pointFreeResult.value;
+		const location = createLocation(match.location.start, close.location.end);
+		const scrutineeVar: Expression = {
+			kind: 'variable',
+			name: '__match_x',
+			location,
+		};
+		const matchExpr: MatchExpression = {
+			kind: 'match',
+			expression: scrutineeVar,
+			cases,
+			location,
+		};
+		const fn: FunctionExpression = {
+			kind: 'function',
+			params: ['__match_x'],
+			body: matchExpr,
+			location,
+		};
+		return {
+			success: true,
+			value: fn,
+			remaining: pointFreeResult.remaining,
+		};
+	}
+
+	return C.map(
+		C.seq(
+			C.lazy(() => parseThrush), // Use a simpler expression parser to avoid circular dependency
+			parseMatchArms
+		),
+		([expression, { cases, close }]): Expression => ({
+			kind: 'match',
+			expression,
+			cases,
+			location: createLocation(match.location.start, close.location.end),
+		})
+	)(matchResult.remaining);
+};
 
 // --- Where Expression ---
 const parseWhereExpression: C.Parser<WhereExpression> = C.map(

--- a/test/features/pattern-matching/point_free_match.test.ts
+++ b/test/features/pattern-matching/point_free_match.test.ts
@@ -1,0 +1,64 @@
+import { test, expect } from 'bun:test';
+import { runCode } from '../../utils';
+
+// Point-free `match`: `match (arms)` with the scrutinee omitted desugars to
+// `fn __match_x => match __match_x (arms)`, the same category of pure
+// parse-time sugar as operator sectioning (`(op)` -> `fn a b => a op b`,
+// see test/features/operators/dollar_operator.test.ts and
+// parseOperatorSection in src/parser/parser.ts). Lets `fn foo => match
+// (foo) (...)` eta-reduce to `match (...)`.
+//
+// `match (` is shared with the existing `match (scrutinee) (arms)` form, so
+// this suite also covers the adversarial cases from
+// docs/internal/docs-wip/POINT_FREE_MATCH_PLAN.md's ambiguity spike: a
+// parenthesized scrutinee that's a bare identifier, and one that's a
+// parenthesized single-arg lambda. Both must keep parsing as the existing
+// two-argument form, unaffected by the new point-free branch.
+
+test('point-free match desugars to a function', () => {
+	const result = runCode(`
+        classify = match (Some x => x; None => 0);
+        classify (Some 5)
+      `);
+	expect(result.finalValue).toEqual(5);
+});
+
+test('point-free match works applied inline', () => {
+	const result = runCode(`
+        (match (Some x => x; None => 0)) (Some 5)
+      `);
+	expect(result.finalValue).toEqual(5);
+});
+
+test('point-free match is usable as a higher-order argument', () => {
+	const result = runCode(`
+        map (match (Some x => x; None => 0)) [Some 1, None, Some 3]
+      `);
+	expect(result.finalValue).toEqual([1, 0, 3]);
+});
+
+test('adversarial: parenthesized bare-identifier scrutinee still parses as the two-argument form', () => {
+	const result = runCode(`
+        foo = Some 5;
+        match (foo) (Some x => x; None => 0)
+      `);
+	expect(result.finalValue).toEqual(5);
+});
+
+test('adversarial: parenthesized single-arg lambda scrutinee still parses as the two-argument form', () => {
+	const result = runCode(`
+        match (fn x => x) (_ => "matched")
+      `);
+	expect(result.finalValue).toEqual('matched');
+});
+
+test('point-free match is eta-equivalent to the pointful lambda wrapper', () => {
+	const pointful = runCode(`
+        fn foo => match (foo) (Some x => x; None => 0)
+      `);
+	const pointfree = runCode(`
+        match (Some x => x; None => 0)
+      `);
+	// Both should produce callable functions with the same behavior.
+	expect(typeof pointful.finalValue).toEqual(typeof pointfree.finalValue);
+});

--- a/test/features/pattern-matching/point_free_match.test.ts
+++ b/test/features/pattern-matching/point_free_match.test.ts
@@ -53,12 +53,18 @@ test('adversarial: parenthesized single-arg lambda scrutinee still parses as the
 });
 
 test('point-free match is eta-equivalent to the pointful lambda wrapper', () => {
+	// Apply both forms to the same inputs and compare actual results (not
+	// just typeof) and inferred types, so this would fail if the desugaring
+	// diverged in behavior, not just in shape.
 	const pointful = runCode(`
-        fn foo => match (foo) (Some x => x; None => 0)
+        f = fn foo => match (foo) (Some x => x; None => 0);
+        {f (Some 5), f None}
       `);
 	const pointfree = runCode(`
-        match (Some x => x; None => 0)
+        g = match (Some x => x; None => 0);
+        {g (Some 5), g None}
       `);
-	// Both should produce callable functions with the same behavior.
-	expect(typeof pointful.finalValue).toEqual(typeof pointfree.finalValue);
+	expect(pointfree.finalValue).toEqual(pointful.finalValue);
+	expect(pointfree.finalValue).toEqual([5, 0]);
+	expect(pointfree.finalType).toEqual(pointful.finalType);
 });

--- a/test/features/pattern-matching/point_free_match.test.ts
+++ b/test/features/pattern-matching/point_free_match.test.ts
@@ -1,58 +1,62 @@
 import { test, expect } from 'bun:test';
 import { runCode } from '../../utils';
 
-// Point-free `match`: `match (arms)` with the scrutinee omitted desugars to
-// `fn __match_x => match __match_x (arms)`, the same category of pure
-// parse-time sugar as operator sectioning (`(op)` -> `fn a b => a op b`,
-// see test/features/operators/dollar_operator.test.ts and
-// parseOperatorSection in src/parser/parser.ts). Lets `fn foo => match
-// (foo) (...)` eta-reduce to `match (...)`.
+// Point-free `match`: `match_ (arms)` — scrutinee omitted, argument moved
+// to last position, per the trailing-underscore "flipped form" convention
+// (docs/internal/adrs/0001-trailing-underscore-flip.md) — desugars to
+// `fn __match_x => match __match_x (arms)`. Lets `fn foo => match (foo)
+// (...)` eta-reduce to `match_ (...)`.
 //
-// `match (` is shared with the existing `match (scrutinee) (arms)` form, so
-// this suite also covers the adversarial cases from
-// docs/internal/docs-wip/POINT_FREE_MATCH_PLAN.md's ambiguity spike: a
-// parenthesized scrutinee that's a bare identifier, and one that's a
-// parenthesized single-arg lambda. Both must keep parsing as the existing
-// two-argument form, unaffected by the new point-free branch.
+// `match_` is lexed as its own distinct KEYWORD token (src/lexer/lexer.ts),
+// separate from `match` — there is no shared prefix with the two-argument
+// `match <scrutinee> (arms)` form, so unlike an earlier version of this
+// feature (which spelled point-free match as `match (arms)` and
+// disambiguated from `match (scrutinee) (arms)` via parser backtracking),
+// there is no ambiguity to test for here: the lexer has already told the
+// two forms apart before the parser sees either.
 
-test('point-free match desugars to a function', () => {
+test('point-free match_ desugars to a function', () => {
 	const result = runCode(`
-        classify = match (Some x => x; None => 0);
+        classify = match_ (Some x => x; None => 0);
         classify (Some 5)
       `);
 	expect(result.finalValue).toEqual(5);
 });
 
-test('point-free match works applied inline', () => {
+test('point-free match_ works applied inline', () => {
 	const result = runCode(`
-        (match (Some x => x; None => 0)) (Some 5)
+        (match_ (Some x => x; None => 0)) (Some 5)
       `);
 	expect(result.finalValue).toEqual(5);
 });
 
-test('point-free match is usable as a higher-order argument', () => {
+test('point-free match_ is usable as a higher-order argument', () => {
 	const result = runCode(`
-        map (match (Some x => x; None => 0)) [Some 1, None, Some 3]
+        map (match_ (Some x => x; None => 0)) [Some 1, None, Some 3]
       `);
 	expect(result.finalValue).toEqual([1, 0, 3]);
 });
 
-test('adversarial: parenthesized bare-identifier scrutinee still parses as the two-argument form', () => {
+test('match_ with a wildcard catch-all', () => {
 	const result = runCode(`
-        foo = Some 5;
-        match (foo) (Some x => x; None => 0)
+        describe = match_ (Some x => "got " + show x; _ => "nothing");
+        describe None
       `);
-	expect(result.finalValue).toEqual(5);
+	expect(result.finalValue).toEqual('nothing');
 });
 
-test('adversarial: parenthesized single-arg lambda scrutinee still parses as the two-argument form', () => {
+test('nested match_ inside an ordinary match case body', () => {
 	const result = runCode(`
-        match (fn x => x) (_ => "matched")
+        unwrapTwice = fn opt => match opt (
+            Some inner => (match_ (Some x => x; None => -1)) inner;
+            None => -2
+        );
+        unwrapTwice (Some (Some 7))
       `);
-	expect(result.finalValue).toEqual('matched');
+	expect(result.finalValue).toEqual(7);
 });
 
-test('point-free match is eta-equivalent to the pointful lambda wrapper', () => {
+test('point-free match_ is eta-equivalent to the pointful lambda wrapper', () => {
 	// Apply both forms to the same inputs and compare actual results (not
 	// just typeof) and inferred types, so this would fail if the desugaring
 	// diverged in behavior, not just in shape.
@@ -61,7 +65,7 @@ test('point-free match is eta-equivalent to the pointful lambda wrapper', () => 
         {f (Some 5), f None}
       `);
 	const pointfree = runCode(`
-        g = match (Some x => x; None => 0);
+        g = match_ (Some x => x; None => 0);
         {g (Some 5), g None}
       `);
 	expect(pointfree.finalValue).toEqual(pointful.finalValue);


### PR DESCRIPTION
## Summary
- Reworked from an earlier `match (arms)` design (reused `match`'s own `(` prefix, disambiguated from `match (scrutinee) (arms)` via parser backtracking). That was parser-sound but reader-opaque — the reviewer (project owner) flagged that a human needs the same lookahead the parser does, which is real magic even when the grammar is unambiguous.
- Per `docs/internal/adrs/0001-trailing-underscore-flip.md`: a trailing underscore names a construct's "flipped" form (first argument to last position, à la `flip`). `match` is special syntax with no runtime value to flip, so it gets its own dedicated keyword: `match_`.
- `match_` is lexed as its own distinct `KEYWORD` token in `src/lexer/lexer.ts`, alongside `match` — not a mode switch on `match`'s own prefix. `match_ (arms)` desugars at parse time to `fn __match_x => match __match_x (arms)`, same synthetic-`FunctionExpression` technique as operator sectioning.
- `parseMatchExpression` (`src/parser/parser.ts`) is back to its original simple form (no branching, no backtracking). New `parseMatchUnderscoreExpression` handles `match_` unconditionally point-free, wired into every call site that previously listed `parseMatchExpression` alone (lambda bodies, nested match-case expressions, `where`-clause main expressions, the fast-dispatch keyword switch).
- Same OCaml (`function` vs `fun`)/Haskell (`\case`/LambdaCase) precedent the ADR cites: pay for a second, lexically distinct token rather than overload the first construct's prefix.

## Test plan
- [x] `test/features/pattern-matching/point_free_match.test.ts` — point-free form, inline application, higher-order use, wildcard catch-all, nesting inside an ordinary `match` case, and eta-equivalence (same result *and* inferred type) against the pointful `fn foo => match (foo) (...)` wrapper.
- [x] `NO_COLOR=1 bun src/cli.ts --types` confirms `match_ (arms)` and its pointful equivalent infer the identical type (`Option Float -> Float`); the ordinary `match (scrutinee) (arms)` form is unaffected.
- [x] `bun run typecheck` clean.
- [x] `AGENT=1 bun test` — 1323 pass, 0 fail.
- [x] `node validate_examples.js` — all docs pass, including the `match_` example blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)