### PR TITLE
Add std/json: hand-written JSON parser/serializer in pure noolang

### DIFF
--- a/docs/internal/docs-wip/EMPTY_LIST_TYPEVAR_COLLISION_BUG.md
+++ b/docs/internal/docs-wip/EMPTY_LIST_TYPEVAR_COLLISION_BUG.md
@@ -1,0 +1,106 @@
+# Bare `[]` literals share a hardcoded type-variable name across statements
+
+Filed 2026-08-01, found while building `std/json.noo` (PR #165). Worked
+around there with `list_filter (fn _ => False) [dummy]` in place of bare
+`[]`; see `empty_json_array`/`empty_json_object` in that file.
+
+## Symptom
+
+A bare `[]` passed to two *different* constructors of the same recursive
+variant, where the constructors' payloads are `List T` vs `List {String, T}`
+(one bare, one tuple-wrapped), fails to unify — even across two unrelated
+top-level bindings, order-independent. Minimal repro:
+
+```
+variant M = MA (List Float) | MO (List {String, Float});
+x = MO [];
+y = MA [];
+x
+```
+
+```
+TypeError: Cannot unify types
+  Expected: Float
+  Got:      (String Float)
+```
+
+Swap the definition order and the error flips to which one complains.
+
+Confirmed boundaries:
+- A **non-empty** list literal (`MO [{"", JN}]` / `MA [JN]`) never triggers
+  it — same constructors, same variant, only the literal differs.
+- Reusing the **same** constructor twice with `[]` (`x = MO []; y = MO []`)
+  never triggers it — needs two different constructors.
+- A variant with two constructors over bare `T` vs `{String, T}` **without**
+  `List` (`variant M = MA Float | MO {String, Float}`) never triggers it —
+  the bug is specifically in list-literal typing, not variant-application
+  typing.
+
+## Root cause
+
+`typeList` in `src/typer/type-inference.ts`, the empty-list case:
+
+```ts
+if (expr.elements.length === 0) {
+    // Empty list - we can't infer the element type
+    return createPureTypeResult(listTypeWithElement(typeVariable('a')), state);
+}
+```
+
+Every other placeholder-type site in this file mints a fresh type variable
+via `freshTypeVariable(state)`, which returns a uniquely-named variable and
+an incremented counter threaded through `state` (see lines 152-153, 432,
+784, 1090, 1380/1382, 1808, 1849/1854, 1902, 1974, and the equivalent calls
+in `pattern-matching.ts`/`trait-function-handling.ts`). This one site is the
+exception: it hardcodes the literal name `'a'` via `typeVariable('a')`
+(`src/ast.ts:639`) instead of generating a fresh one.
+
+`state.substitution` is a single map keyed by variable *name*, threaded
+through the entire top-level program (`unifyInternal` in
+`src/typer/unify.ts` reads/writes it by `t.name`, e.g. `state.substitution.
+get(currentVar.name)`). Because every bare `[]` produces a type variable
+literally named `a`, two unrelated empty-list literals in different
+top-level bindings collide on that name. Unifying `MO []` against `List
+{String, Float}` binds `a ↦ {String, Float}` in the shared substitution.
+That binding outlives the statement. When `MA []`'s `[]` — same literal name
+`a` — later unifies against `List Float`, unify finds the stale `a ↦
+{String, Float}` still in the map and fails against `Float`.
+
+This explains every observed boundary: order-independence (whichever
+binding runs first "wins" the collision and poisons the second); cross-
+binding leakage (one substitution map, not scoped per statement); why
+nonempty lists don't trigger it (their element type comes from real
+inference, not the placeholder); why `List` is required (the bug is in
+`typeList` specifically, not constructor-application typing); why two
+different constructors are needed (`MO []; MO []` unifies the same payload
+type both times, no conflict); and why a `List`-free variant doesn't trigger
+it (no `[]` literal involved at all).
+
+## Fix shape (not applied here — needs its own PR/review)
+
+One-line fix, verified working during investigation for this doc (applied
+temporarily, confirmed the repro above passes and infers `M` correctly,
+then reverted so this bug doc's PR doesn't silently include an untested
+typer change):
+
+```ts
+if (expr.elements.length === 0) {
+    const [freshVar, freshState] = freshTypeVariable(state);
+    return createPureTypeResult(listTypeWithElement(freshVar), freshState);
+}
+```
+
+Unlike `TRAIT_SYSTEM_ARITY_BUG.md`, this does not look like a systemic
+redesign — it's a single missed call to an existing helper that every
+sibling call site already uses correctly. Worth a repo-wide grep for the
+same `typeVariable('<literal-name>')` anti-pattern before landing the fix,
+in case this isn't the only site — that sweep was out of scope for this
+investigation (bounded-effort, this bug only).
+
+## Trigger for picking this up
+
+Any stdlib or userland code hits it incidentally the moment it uses a bare
+`[]` for two differently-shaped `List`-payload constructors of one variant —
+easy to hit by accident (see `std/json.noo`'s `ParseMode`/`JsonValue`, both
+of which have this exact `List T` / `List {String, T}` shape). Low risk,
+high value, one-line fix — good candidate for a quick standalone PR.

--- a/docs/internal/docs-wip/PARSER_COMBINATOR_SIZE_COST.md
+++ b/docs/internal/docs-wip/PARSER_COMBINATOR_SIZE_COST.md
@@ -1,0 +1,99 @@
+# Parsing a large `.noo` file has a steep, non-obviously-localized cost
+
+Filed 2026-08-01, found while building/reviewing `std/json.noo` (PR #165).
+Not fixed here — this is a report for whoever picks up the parser
+performance work next, not a resolved issue.
+
+## Symptom
+
+Typechecking `std/json.noo` (~575 lines) costs ~14-15s per process, almost
+entirely in the **Parse** phase of noolang's own combinator parser (parsing
+the `.noo` *source file*, not JSON text) — confirmed via `NO_COLOR=1 bun
+src/cli.ts --verbose std/json.noo`'s phase breakdown (`Parse: ~14.5s` out of
+~14.6s total; `Type` is ~70ms). This is a one-time cost per process — the
+module cache (`src/module-loader.ts`) means it's paid once regardless of how
+many times `std/json` is imported in the same run — but it's still large
+enough to need `setDefaultTimeout(30000)` in
+`test/features/std-json-module.test.ts` to avoid bun's 5000ms default
+timing out the first test in that file.
+
+This was originally ~30-43s before a round of refactoring (documented in PR
+#165's history) that extracted the parser's single most deeply-nested
+function (`parse_node`, a ~130-line match-of-matches) into several smaller
+top-level leaf functions, cutting the cost roughly in half. That refactor's
+success suggested a hypothesis: **cost scales with nesting depth within a
+single function's body**, and shrinking the deepest function should keep
+helping.
+
+## That hypothesis is wrong, or at least badly incomplete
+
+Applying the *exact same technique* to `parse_number` — the next-largest
+single function, itself fairly deeply nested (nested `if`/`match`/`result_bind`
+chains for the fraction and exponent grammar) — produced the opposite of
+the expected result:
+
+- Extracting `parse_number`'s three phases (leading integer, fraction,
+  exponent) into three flat leaf functions (`scan_leading_int`,
+  `scan_fraction`, `scan_exponent`), each individually shallow, and
+  reducing `parse_number` itself to three chained `result_bind` calls with
+  minimal nesting —
+- took the whole file's parse time from **~14.8s to ~72.3s** (confirmed
+  reproducible: reapplied and re-measured twice, both times ~72s, not
+  noise).
+
+The change was reverted (not shipped); `git log`/PR #165's diff history has
+the before/after if someone wants to reproduce this exactly. The net
+top-level-binding-count delta was small (+2: three new functions replacing
+inline code), and the file got *shorter* overall (fewer total lines than
+before, since the extracted functions were flatter than what they
+replaced) — so "more top-level statements" and "more total lines" don't
+explain a 5x regression either, on their own.
+
+## What this rules out
+
+- **Not nesting depth in isolation** — the same "extract to reduce nesting"
+  move helped once (parse_node) and hurt badly once (parse_number).
+- **Not raw line/character count** — the file got shorter and slower.
+- **Not simply "more top-level bindings is worse"** — the successful
+  `parse_node` extraction also added several new top-level bindings
+  (`open_container`, `parse_object_key_and_colon`, `decide_separator`, two
+  new `variant`s) and that made things *faster*.
+
+## What's still unknown
+
+No working theory yet for what specifically makes one extraction help and
+a structurally-similar one hurt this badly. Candidates not yet
+investigated (bounded effort spent here, did not chase further):
+
+- Something specific to `parse_number`'s *particular* extraction shape —
+  e.g. three sibling functions all taking `(Float, String)` and all calling
+  `scan_digits`/`peek_char`, vs. `parse_node`'s extracted helpers, which
+  have more varied signatures. Possibly a case where the parser combinator
+  backtracks across *candidate productions that look similar to each
+  other* specifically, not nesting depth per se.
+- Something about where in the file the change lands — `parse_number`
+  comes right after `scan_content` (also a large function); maybe
+  cumulative/interacting cost between adjacent large-ish functions, not
+  purely local to the one being changed.
+- A genuine non-monotonicity in the underlying algorithm (e.g. exponential
+  backtracking that's sensitive to exact choice-point count/order in ways
+  that don't reduce to a simple size or depth metric).
+
+## Where to look
+
+`src/parser/` — this project's own combinator parser (`C.choice`,
+`C.lazy`, etc., per `src/parser/combinators.ts` and `src/parser/parser.ts`).
+No profiling was done inside the parser itself for this investigation (only
+black-box timing via the CLI's `--verbose` phase breakdown and bisection by
+truncating `std/json.noo` at statement boundaries) — an actual profile
+(`--prof` / flamegraph on `bun src/cli.ts std/json.noo`) would likely
+localize this far faster than further black-box bisection.
+
+## Trigger for picking this up
+
+Any stdlib file crossing a few hundred lines with realistic branching
+structure is likely to hit multi-second-plus parse costs, and per this
+report, "just refactor to reduce nesting" is not a reliable fix without
+understanding the actual mechanism — it can make things much worse. Worth
+picking up before the stdlib grows much further, or before another large
+hand-written `.noo` module (`std/json.noo`-sized or bigger) is attempted.

--- a/json.test.noo
+++ b/json.test.noo
@@ -61,4 +61,16 @@ extraction_tests = group "json_field/json_index/json_as_number" [
     ))
 ];
 
-group "std/json regressions" [parse_tests, roundtrip_tests, extraction_tests]
+spec_gap_tests = group "spec edge cases found in code review" [
+  test_case "duplicate keys: last value wins, first position kept" (fn _ =>
+    expect_eq "{\"a\":3,\"b\":2}"
+      (unwrap_or "?" (match (json_parse "{\"a\":1,\"b\":2,\"a\":3}") (Ok v => Ok (json_stringify v); Err e => Err e)))),
+  test_case "rejects a leading zero" (fn _ =>
+    expect "\"01\" is an error" (is_err (json_parse "01"))),
+  test_case "rejects a raw unescaped control character in a string" (fn _ =>
+    expect "a literal tab byte in a string is an error" (is_err (json_parse "\"a\tb\""))),
+  test_case "json_stringify emits null for an overflowed (non-finite) number" (fn _ =>
+    expect_eq "null" (unwrap_or "?" (match (json_parse "1e400") (Ok v => Ok (json_stringify v); Err e => Err e))))
+];
+
+group "std/json regressions" [parse_tests, roundtrip_tests, extraction_tests, spec_gap_tests]

--- a/json.test.noo
+++ b/json.test.noo
@@ -1,0 +1,64 @@
+# Runtime regression suite for std/json.noo, run by `noo test` (not `bun
+# test`). Complements test/features/std-json-module.test.ts the way
+# stdlib.test.noo complements the rest of test/ — see CLAUDE.md's Tests
+# section. Exercises the module as an imported consumer would, on real
+# JSON text.
+
+{@test_case test_case, @group group, @expect_eq expect_eq, @expect expect} = import "std/test";
+{@json_parse json_parse, @json_stringify json_stringify, @json_equals json_equals,
+ @json_field json_field, @json_index json_index, @json_as_number json_as_number}
+  = import "std/json";
+
+is_ok = fn r => match r (Ok _ => True; Err _ => False);
+is_err = fn r => match r (Ok _ => False; Err _ => True);
+unwrap_or = fn default r => match r (Ok v => v; Err _ => default);
+
+parse_tests = group "json_parse" [
+  test_case "parses a flat object" (fn _ =>
+    expect_eq "{\"a\":1,\"b\":2}"
+      (unwrap_or "?" (match (json_parse "{\"a\":1,\"b\":2}") (Ok v => Ok (json_stringify v); Err e => Err e)))),
+  test_case "parses a nested structure" (fn _ =>
+    expect_eq "{\"items\":[1,2,3],\"ok\":true}"
+      (unwrap_or "?" (match (json_parse "{\"items\":[1,2,3],\"ok\":true}") (Ok v => Ok (json_stringify v); Err e => Err e)))),
+  test_case "rejects malformed input" (fn _ =>
+    expect "unclosed object is an error" (is_err (json_parse "{\"a\":"))),
+  test_case "rejects trailing garbage" (fn _ =>
+    expect "trailing content is an error" (is_err (json_parse "1 2")))
+];
+
+roundtrip_tests = group "json_stringify . json_parse round-trips" [
+  test_case "round-trips a mixed-shape document" (fn _ => (
+    src = "{\"name\":\"Ada\",\"scores\":[1,2,3],\"meta\":{\"active\":true,\"note\":null}}";
+    match (json_parse src) (
+      Ok v => match (json_parse (json_stringify v)) (
+        Ok v2 => expect "re-parsed value equals the original" (json_equals v v2);
+        Err _ => expect "re-parse failed" False
+      );
+      Err _ => expect "initial parse failed" False
+    )
+  ))
+];
+
+extraction_tests = group "json_field/json_index/json_as_number" [
+  test_case "json_field finds a nested field" (fn _ =>
+    match (json_parse "{\"user\":{\"age\":30}}") (
+      Ok v => match (json_field "user" v) (
+        Ok user => expect_eq (Ok 30)
+          (match (json_field "age" user) (Ok a => json_as_number a; Err e => Err e));
+        Err _ => expect "missing user field" False
+      );
+      Err _ => expect "parse failed" False
+    )),
+  test_case "json_index reaches an array element" (fn _ =>
+    match (json_parse "[10,20,30]") (
+      Ok v => expect_eq (Ok 20) (match (json_index 1 v) (Ok e => json_as_number e; Err e => Err e));
+      Err _ => expect "parse failed" False
+    )),
+  test_case "json_field on a missing key is an error" (fn _ =>
+    match (json_parse "{\"a\":1}") (
+      Ok v => expect "missing key is Err" (is_err (json_field "z" v));
+      Err _ => expect "parse failed" False
+    ))
+];
+
+group "std/json regressions" [parse_tests, roundtrip_tests, extraction_tests]

--- a/std/json.noo
+++ b/std/json.noo
@@ -10,9 +10,18 @@
 #   - \u XXXX escapes in JSON string literals are rejected (ParseError),
 #     not decoded.
 #   - \b and \f escapes are rejected for the same reason.
-#   - Serialization escapes only quote/backslash/newline/cr/tab; other C0
-#     control characters pass through unescaped (round-trips through this
-#     parser fine, may not be valid strict-JSON for input built elsewhere).
+#   - Serialization escapes only quote/backslash/newline/cr/tab. A JsonValue
+#     built by hand (not via json_parse, which now rejects raw control
+#     characters — see scan_content) could still carry other C0 control
+#     characters in a JString; those pass through json_stringify unescaped.
+#   - `-0` loses its sign on parse and can't be recovered on stringify —
+#     see the comment on `signed_mantissa` in parse_number.
+#
+# Explicit spec choices (RFC 8259), not gaps:
+#   - Duplicate object keys: last value wins, first occurrence keeps its
+#     position — matches JS's JSON.parse (see ModeObjectNext).
+#   - Leading zeros in the integer part ("01") are rejected (see
+#     parse_number's has_leading_zero check).
 
 variant JsonValue =
     JNull
@@ -129,32 +138,90 @@ parse_keyword = fn keyword value pos s => (
     else parse_error ("expected '" + keyword + "'") pos
 );
 
-scan_string = fn pos s acc => match (peek_char pos s) (
-  None => parse_error "unterminated string" pos;
-  Some c => match c (
-    "\"" => Ok {@value acc, @pos (pos + 1)};
-    "\\" => match (peek_char (pos + 1) s) (
-      None => parse_error "unterminated escape" (pos + 1);
-      Some e => match e (
-        "\"" => scan_string (pos + 2) s (acc + "\"");
-        "\\" => scan_string (pos + 2) s (acc + "\\");
-        "/" => scan_string (pos + 2) s (acc + "/");
-        "n" => scan_string (pos + 2) s (acc + "\n");
-        "r" => scan_string (pos + 2) s (acc + "\r");
-        "t" => scan_string (pos + 2) s (acc + "\t");
-        "u" => parse_error "\\u escapes are not supported" pos;
-        "b" => parse_error "\\b escapes are not supported" pos;
-        "f" => parse_error "\\f escapes are not supported" pos;
-        _ => parse_error ("invalid escape character '" + e + "'") (pos + 1)
-      )
-    );
-    _ => scan_string (pos + 1) s (acc + c)
+is_some = fn opt => match opt (Some _ => True; None => False);
+
+# Scanning a string char-by-char via noolang-level recursion (`scan_string
+# (pos+1) s ...`) — even with a cheap accumulator, even though it's written
+# in tail position — still grows the JS call stack one frame per input
+# character: this evaluator has no tail-call optimization, so "tail
+# position" doesn't mean anything for stack depth here. Confirmed: even
+# after switching the accumulator to a `List String` joined once (the fix
+# that looked sufficient by analogy with `escape_string` below), a 6000-char
+# string value still overflows ("Maximum call stack size exceeded"). The
+# actual fix has to avoid noolang-level recursion per character entirely.
+#
+# `escape_string` doesn't hit this because `list_map`/`reduce` are native
+# JS loops (`Array.prototype.map`/`reduce` in the evaluator) — each element
+# call returns before the next begins, so stack depth stays O(1) regardless
+# of list length. `scan_content` below is the same idea applied to string
+# scanning: one `reduce` over the remaining characters, carrying an
+# explicit state record, instead of one noolang function call per
+# character. It intentionally does *not* stop at the closing quote —
+# `reduce` has no early-exit, so remaining characters after the string
+# closes are walked but ignored (`is_some (state | @closed_at)` short-
+# circuits to a no-op). That's O(document length) of wasted iteration per
+# string rather than O(this string's length); acceptable for the crash fix
+# this exists for, but a real cost for a document with many short strings —
+# worth revisiting with an `indexOf`-based fast path if that ever shows up
+# in practice.
+scan_content = fn pos s => (
+  doc_len = length (chars s);
+  remaining = chars (substring pos doc_len s);
+  # No `: Option JsonParseError` ascription on the `@error` field: noolang
+  # resolves a same-named type/constructor pair (`variant JsonParseError =
+  # JsonParseError {...}`) to the *constructor's* function type in type
+  # position, not the variant type — confirmed with a minimal repro
+  # (`variant E = E {@f Float}; (None : Option E)` infers `Option ({@f
+  # Float}) -> E`, not `Option E`). Leaving `@error`'s type to be inferred
+  # from the `Some (JsonParseError ...)` branches below sidesteps it.
+  init = {@parts ([] : List String), @escaped False, @closed_at (None : Option Float), @error None, @i pos};
+  step = fn state ch => (
+    already_done = (is_some (state | @closed_at)) || (is_some (state | @error));
+    if already_done then state else (
+      i = state | @i;
+      parts = state | @parts;
+      next_i = i + 1;
+      if state | @escaped
+        then match ch (
+          "\"" => {@parts (append parts ["\""]), @escaped False, @closed_at None, @error None, @i next_i};
+          "\\" => {@parts (append parts ["\\"]), @escaped False, @closed_at None, @error None, @i next_i};
+          "/" => {@parts (append parts ["/"]), @escaped False, @closed_at None, @error None, @i next_i};
+          "n" => {@parts (append parts ["\n"]), @escaped False, @closed_at None, @error None, @i next_i};
+          "r" => {@parts (append parts ["\r"]), @escaped False, @closed_at None, @error None, @i next_i};
+          "t" => {@parts (append parts ["\t"]), @escaped False, @closed_at None, @error None, @i next_i};
+          "u" => {@parts parts, @escaped False, @closed_at None, @error (Some (JsonParseError {@message "\\u escapes are not supported", @position (i - 1)})), @i next_i};
+          "b" => {@parts parts, @escaped False, @closed_at None, @error (Some (JsonParseError {@message "\\b escapes are not supported", @position (i - 1)})), @i next_i};
+          "f" => {@parts parts, @escaped False, @closed_at None, @error (Some (JsonParseError {@message "\\f escapes are not supported", @position (i - 1)})), @i next_i};
+          _ => {@parts parts, @escaped False, @closed_at None, @error (Some (JsonParseError {@message ("invalid escape character '" + ch + "'"), @position i})), @i next_i}
+        )
+        else match ch (
+          "\"" => {@parts parts, @escaped False, @closed_at (Some next_i), @error None, @i next_i};
+          "\\" => {@parts parts, @escaped True, @closed_at None, @error None, @i next_i};
+          # RFC 8259 §7: raw (unescaped) C0 control characters are illegal
+          # inside a JSON string. `ch < " "` is a codepoint comparison in
+          # disguise — noolang has no charCodeAt, but `<` on two 1-char
+          # strings is `primitive_string_less_than`, i.e. a JS `<` on
+          # single UTF-16 code units, so it orders exactly like the
+          # codepoints would.
+          _ => if ch < " "
+            then {@parts parts, @escaped False, @closed_at None, @error (Some (JsonParseError {@message "control character must be escaped", @position i})), @i next_i}
+            else {@parts (append parts [ch]), @escaped False, @closed_at None, @error None, @i next_i}
+        )
+    )
+  );
+  final = reduce step init remaining;
+  match (final | @error) (
+    Some e => Err e;
+    None => match (final | @closed_at) (
+      Some endpos => Ok {@value (join "" (final | @parts)), @pos endpos};
+      None => parse_error "unterminated string" (final | @i)
+    )
   )
 );
 
 # Raw string content (no JString wrapper) starting at the opening quote;
 # returns the position just past the closing quote.
-parse_string_raw = fn pos s => scan_string (pos + 1) s "";
+parse_string_raw = fn pos s => scan_content (pos + 1) s;
 
 parse_json_string = fn pos s =>
   result_map (fn r => {@value (JString (r | @value)), @pos (r | @pos)}) (parse_string_raw pos s);
@@ -168,6 +235,10 @@ parse_number = fn pos s => (
       int_scan = scan_digits pos1 s 0;
       int_val = int_scan | @value;
       pos2 = int_scan | @pos;
+      # RFC 8259 §6: the integer part is `0` alone, or a nonzero digit
+      # followed by more digits — "01", "007" etc. are not valid numbers.
+      has_leading_zero = (fd == "0") && ((pos2 - pos1) > 1);
+      if has_leading_zero then parse_error "leading zeros are not allowed" pos1 else (
       has_frac = (peek_char pos2 s) == Some ".";
       frac_step =
         if has_frac then (
@@ -205,10 +276,22 @@ parse_number = fn pos s => (
           exp = er | @exp;
           pos4 = er | @pos;
           mantissa = int_val + frac;
+          # `-0` loses its sign here (`0 - 0` is `+0`, not `-0`) and stays
+          # lost: `toString` on the resulting Float goes through JS's
+          # `Number.prototype.toString`, where `(-0).toString() === "0"`
+          # regardless of the sign bit. Preserving the sign through parsing
+          # alone (e.g. `mantissa * -1`, which JS does keep as `-0`)
+          # wouldn't be observable in `json_stringify`'s output without
+          # `json_stringify` separately special-casing negative zero — and
+          # noolang has no sign-of-zero test to do that with (no
+          # `Object.is`-equivalent, and `/`'s divide-by-zero guard doesn't
+          # distinguish `-0` from `0`). Left as a known gap rather than a
+          # fix that wouldn't actually round-trip `-0`.
           signed_mantissa = if neg then (0 - mantissa) else mantissa;
           Ok {@value (JNumber (apply_exponent signed_mantissa exp)), @pos pos4}
         ))
       ))
+      )
     )
   )
 );
@@ -248,6 +331,64 @@ variant ParseMode =
 empty_json_array = list_filter (fn _ => False) [JNull];
 empty_json_object = list_filter (fn _ => False) [{"", JNull}];
 
+# --- Leaf helpers for parse_node ---
+#
+# None of these call `parse_node` — they're ordinary, non-recursive
+# top-level functions. Pulling them out of parse_node's body (rather than
+# inlining) isn't just tidiness: a bisection on typecheck time (see PR
+# description) localized a ~30s-per-process cost specifically to
+# parse_node's own body size once every branch's full logic lived inside
+# one match expression. Shrinking that one function's textual/AST bulk by
+# moving anything that *can* live outside it (i.e. doesn't need
+# self-recursion) is the whole point of these three helpers.
+
+# Opening `{` or `[` (pos already past the bracket): either it's
+# immediately empty, or parse_node needs to continue in the corresponding
+# ...Next mode. `continue_mode` is a fully-built ParseMode value (the
+# caller already knows which one), not a function — this stays a leaf.
+variant OpenDecision = OpenEmpty JsonValue Float | OpenContinue ParseMode Float;
+
+open_container = fn close_char pos s empty_value continue_mode => (
+  p1 = skip_ws pos s;
+  if (peek_char p1 s) == Some close_char
+    then OpenEmpty empty_value (p1 + 1)
+    else OpenContinue continue_mode p1
+);
+
+# Object member key: string key through the colon, positioned at the
+# start of the value. Everything up to (not including) parsing the value
+# itself — the one part of "parse an object member" that doesn't recurse.
+parse_object_key_and_colon = fn pos s => (
+  p = skip_ws pos s;
+  match (peek_char p s) (
+    None => parse_error "unterminated object" p;
+    Some c => if not (c == "\"") then parse_error "expected string key" p else
+      result_bind (parse_string_raw p s) (fn keyRes => (
+        p1 = skip_ws (keyRes | @pos) s;
+        result_bind (expect_char ":" p1 s) (fn p2 =>
+          Ok {@key (keyRes | @value), @pos (skip_ws p2 s)}
+        )
+      ))
+  )
+);
+
+# After an array/object element: is there a `,` (more to come), the
+# closing bracket (done), or neither (malformed)? Shared by
+# ModeArrayRest/ModeObjectRest, parameterized by the closing character —
+# their continuation logic was identical but for that one character.
+variant SepDecision = SepComma Float | SepEnd Float | SepError String Float;
+
+decide_separator = fn label close_char pos s => (
+  p = skip_ws pos s;
+  match (peek_char p s) (
+    None => SepError ("unterminated " + label) p;
+    Some c =>
+      if c == "," then SepComma (skip_ws (p + 1) s)
+      else if c == close_char then SepEnd (p + 1)
+      else SepError ("expected ',' or '" + close_char + "'") p
+  )
+);
+
 parse_node = fn mode pos s => match mode (
   ModeValue => (
     p = skip_ws pos s;
@@ -255,17 +396,13 @@ parse_node = fn mode pos s => match mode (
       None => parse_error "unexpected end of input" p;
       Some c => match c (
         "\"" => parse_json_string p s;
-        "{" => (
-          p1 = skip_ws (p + 1) s;
-          if (peek_char p1 s) == Some "}"
-            then Ok {@value (JObject empty_json_object), @pos (p1 + 1)}
-            else parse_node (ModeObjectNext empty_json_object) p1 s
+        "{" => match (open_container "}" (p + 1) s (JObject empty_json_object) (ModeObjectNext empty_json_object)) (
+          OpenEmpty v pos2 => Ok {@value v, @pos pos2};
+          OpenContinue m pos2 => parse_node m pos2 s
         );
-        "[" => (
-          p1 = skip_ws (p + 1) s;
-          if (peek_char p1 s) == Some "]"
-            then Ok {@value (JArray empty_json_array), @pos (p1 + 1)}
-            else parse_node (ModeArrayNext empty_json_array) p1 s
+        "[" => match (open_container "]" (p + 1) s (JArray empty_json_array) (ModeArrayNext empty_json_array)) (
+          OpenEmpty v pos2 => Ok {@value v, @pos pos2};
+          OpenContinue m pos2 => parse_node m pos2 s
         );
         "t" => parse_keyword "true" (JBool True) p s;
         "f" => parse_keyword "false" (JBool False) p s;
@@ -279,42 +416,24 @@ parse_node = fn mode pos s => match mode (
   ModeArrayNext acc => result_bind (parse_node ModeValue pos s) (fn item =>
     parse_node (ModeArrayRest (append acc [item | @value])) (item | @pos) s
   );
-  ModeArrayRest acc => (
-    p = skip_ws pos s;
-    match (peek_char p s) (
-      None => parse_error "unterminated array" p;
-      Some c =>
-        if c == "," then parse_node (ModeArrayNext acc) (skip_ws (p + 1) s) s
-        else if c == "]" then Ok {@value (JArray acc), @pos (p + 1)}
-        else parse_error "expected ',' or ']'" p
+  ModeArrayRest acc => match (decide_separator "array" "]" pos s) (
+    SepComma next => parse_node (ModeArrayNext acc) next s;
+    SepEnd next => Ok {@value (JArray acc), @pos next};
+    SepError msg errPos => parse_error msg errPos
+  );
+  # Duplicate keys: last value wins, first occurrence keeps its position —
+  # matches JS's JSON.parse and RFC 8259's informative guidance.
+  # `assoc_set` already has exactly this behavior (replaces in place if
+  # the key exists, else appends).
+  ModeObjectNext acc => result_bind (parse_object_key_and_colon pos s) (fn kr =>
+    result_bind (parse_node ModeValue (kr | @pos) s) (fn valRes =>
+      parse_node (ModeObjectRest (assoc_set (kr | @key) (valRes | @value) acc)) (valRes | @pos) s
     )
   );
-  ModeObjectNext acc => (
-    p = skip_ws pos s;
-    match (peek_char p s) (
-      None => parse_error "unterminated object" p;
-      Some c => if not (c == "\"") then parse_error "expected string key" p else
-        result_bind (parse_string_raw p s) (fn keyRes => (
-          key = keyRes | @value;
-          p1 = skip_ws (keyRes | @pos) s;
-          result_bind (expect_char ":" p1 s) (fn p2 => (
-            p3 = skip_ws p2 s;
-            result_bind (parse_node ModeValue p3 s) (fn valRes =>
-              parse_node (ModeObjectRest (append acc [{key, valRes | @value}])) (valRes | @pos) s
-            )
-          ))
-        ))
-    )
-  );
-  ModeObjectRest acc => (
-    p = skip_ws pos s;
-    match (peek_char p s) (
-      None => parse_error "unterminated object" p;
-      Some c =>
-        if c == "," then parse_node (ModeObjectNext acc) (skip_ws (p + 1) s) s
-        else if c == "}" then Ok {@value (JObject acc), @pos (p + 1)}
-        else parse_error "expected ',' or '}'" p
-    )
+  ModeObjectRest acc => match (decide_separator "object" "}" pos s) (
+    SepComma next => parse_node (ModeObjectNext acc) next s;
+    SepEnd next => Ok {@value (JObject acc), @pos next};
+    SepError msg errPos => parse_error msg errPos
   )
 );
 
@@ -345,10 +464,24 @@ escape_char = fn c => match c (
 
 escape_string = fn s => join "" (list_map escape_char (chars s));
 
+# JSON has no token for Infinity/NaN, but `JNumber` wraps a plain Float,
+# which can hold either (e.g. `json_parse "1e400"` overflows to Infinity —
+# our own arithmetic, not just a foreign JsonValue someone constructed by
+# hand). `json_stringify`'s signature is `JsonValue -> String`, not a
+# `Result`, so there's no error channel to reject through without a
+# breaking API change; instead, matching JS's own precedent
+# (`JSON.stringify(Infinity) === JSON.stringify(NaN) === "null"`), non-finite
+# values serialize as `"null"` — valid JSON syntax, not the silently-invalid
+# bare `Infinity`/`NaN` token `toString` would otherwise emit.
+non_finite_number_text = fn n => (
+  text = toString n;
+  (text == "Infinity") || (text == "-Infinity") || (text == "NaN")
+);
+
 json_stringify = fn v => match v (
   JNull => "null";
   JBool b => match b (True => "true"; False => "false");
-  JNumber n => toString n;
+  JNumber n => if non_finite_number_text n then "null" else toString n;
   JString s => "\"" + escape_string s + "\"";
   JArray items => "[" + join "," (list_map json_stringify items) + "]";
   JObject members => "{" + join "," (list_map (fn pair => (

--- a/std/json.noo
+++ b/std/json.noo
@@ -1,0 +1,442 @@
+# std/json — JSON parse/serialize, hand-written recursive-descent in plain
+# noolang (no native JSON.parse wrapper). Written as a stdlib-gap forcing
+# function: see docs/internal/docs-wip/JSON_PARSER_PLAN.md for why JsonValue
+# is a concrete variant rather than Unknown (records can't take
+# runtime-computed keys, and Unknown has no isTuple/isRecord to recover a
+# record shape from anyway).
+#
+# Known scope limits (not workarounds — genuine gaps in what's expressible
+# without a codepoint<->char builtin, i.e. no fromCharCode/charCodeAt):
+#   - \u XXXX escapes in JSON string literals are rejected (ParseError),
+#     not decoded.
+#   - \b and \f escapes are rejected for the same reason.
+#   - Serialization escapes only quote/backslash/newline/cr/tab; other C0
+#     control characters pass through unescaped (round-trips through this
+#     parser fine, may not be valid strict-JSON for input built elsewhere).
+
+variant JsonValue =
+    JNull
+  | JBool Bool
+  | JNumber Float
+  | JString String
+  | JArray (List JsonValue)
+  | JObject (List {String, JsonValue});
+
+variant JsonParseError = JsonParseError {@message String, @position Float};
+
+# Extraction errors are a separate variant from parse errors: getting a
+# field out of an already-parsed JsonValue is a different failure mode
+# (wrong shape / missing key) than failing to parse text.
+variant JsonError =
+    JsonExpectedString
+  | JsonExpectedNumber
+  | JsonExpectedBool
+  | JsonExpectedArray
+  | JsonExpectedObject
+  | JsonMissingField String
+  | JsonIndexOutOfBounds Float;
+
+# ========================================
+# Result plumbing
+#
+# Deliberately not using the Monad/Applicative `bind`/`map` trait methods
+# here: those dispatch through trait-instance resolution, and two-parameter
+# variants (Result a b) register at arity 1 there, which crashes the typer
+# on `Result`'s own instances (see stdlib.noo's "KNOWN WRONG" note on
+# Applicative Result, and #158). Plain top-level functions that `match`
+# directly don't go through that path and work fine.
+# ========================================
+
+result_bind = fn res f => match res (
+  Ok x => f x;
+  Err e => Err e
+);
+
+result_map = fn f res => match res (
+  Ok x => Ok (f x);
+  Err e => Err e
+);
+
+# ========================================
+# PARSER
+#
+# Threads a Float character position through the input string. Each
+# sub-parser returns Result {@value V, @pos Float} JsonParseError: on
+# success, the parsed value plus the position just past what it consumed.
+# No chars-list/tokenizer stage — `substring`/`indexOf` operate directly on
+# the source string, which is simpler at JSON's grammar size (see plan doc).
+# ========================================
+
+parse_error = fn message pos => Err (JsonParseError {@message message, @position pos});
+
+# One character at `pos`, or None past the end. A 1-char `substring` is
+# exactly one char or "" out of range, so this doubles as the bounds check.
+peek_char = fn pos s => (
+  c = substring pos (pos + 1) s;
+  if c == "" then None else Some c
+);
+
+is_whitespace = fn c => match c (
+  " " => True; "\t" => True; "\n" => True; "\r" => True; _ => False
+);
+
+skip_ws = fn pos s => match (peek_char pos s) (
+  None => pos;
+  Some c => if is_whitespace c then skip_ws (pos + 1) s else pos
+);
+
+is_digit = fn c => match c (
+  "0" => True; "1" => True; "2" => True; "3" => True; "4" => True;
+  "5" => True; "6" => True; "7" => True; "8" => True; "9" => True;
+  _ => False
+);
+
+digit_value = fn c => match c (
+  "0" => 0; "1" => 1; "2" => 2; "3" => 3; "4" => 4;
+  "5" => 5; "6" => 6; "7" => 7; "8" => 8; "9" => 9;
+  _ => 0
+);
+
+# Consumes digits while they last (may consume zero); caller checks whether
+# `pos` advanced when at-least-one-digit is required.
+scan_digits = fn pos s acc => match (peek_char pos s) (
+  None => {@value acc, @pos pos};
+  Some c => if is_digit c
+    then scan_digits (pos + 1) s (acc * 10 + digit_value c)
+    else {@value acc, @pos pos}
+);
+
+pow10 = fn n => if n <= 0 then 1 else 10 * pow10 (n - 1);
+
+divide_or_zero = fn a b => option_get_or 0 (a / b);
+
+apply_exponent = fn value exp =>
+  if exp == 0 then value
+  else if exp > 0 then value * pow10 exp
+  else divide_or_zero value (pow10 (0 - exp));
+
+expect_char = fn expected pos s => match (peek_char pos s) (
+  Some c => if c == expected then Ok (pos + 1)
+    else parse_error ("expected '" + expected + "'") pos;
+  None => parse_error ("expected '" + expected + "' but reached end of input") pos
+);
+
+parse_keyword = fn keyword value pos s => (
+  klen = length (chars keyword);
+  slice = substring pos (pos + klen) s;
+  if slice == keyword
+    then Ok {@value value, @pos (pos + klen)}
+    else parse_error ("expected '" + keyword + "'") pos
+);
+
+scan_string = fn pos s acc => match (peek_char pos s) (
+  None => parse_error "unterminated string" pos;
+  Some c => match c (
+    "\"" => Ok {@value acc, @pos (pos + 1)};
+    "\\" => match (peek_char (pos + 1) s) (
+      None => parse_error "unterminated escape" (pos + 1);
+      Some e => match e (
+        "\"" => scan_string (pos + 2) s (acc + "\"");
+        "\\" => scan_string (pos + 2) s (acc + "\\");
+        "/" => scan_string (pos + 2) s (acc + "/");
+        "n" => scan_string (pos + 2) s (acc + "\n");
+        "r" => scan_string (pos + 2) s (acc + "\r");
+        "t" => scan_string (pos + 2) s (acc + "\t");
+        "u" => parse_error "\\u escapes are not supported" pos;
+        "b" => parse_error "\\b escapes are not supported" pos;
+        "f" => parse_error "\\f escapes are not supported" pos;
+        _ => parse_error ("invalid escape character '" + e + "'") (pos + 1)
+      )
+    );
+    _ => scan_string (pos + 1) s (acc + c)
+  )
+);
+
+# Raw string content (no JString wrapper) starting at the opening quote;
+# returns the position just past the closing quote.
+parse_string_raw = fn pos s => scan_string (pos + 1) s "";
+
+parse_json_string = fn pos s =>
+  result_map (fn r => {@value (JString (r | @value)), @pos (r | @pos)}) (parse_string_raw pos s);
+
+parse_number = fn pos s => (
+  neg = (peek_char pos s) == Some "-";
+  pos1 = if neg then pos + 1 else pos;
+  match (peek_char pos1 s) (
+    None => parse_error "expected digit" pos1;
+    Some fd => if not (is_digit fd) then parse_error "expected digit" pos1 else (
+      int_scan = scan_digits pos1 s 0;
+      int_val = int_scan | @value;
+      pos2 = int_scan | @pos;
+      has_frac = (peek_char pos2 s) == Some ".";
+      frac_step =
+        if has_frac then (
+          fstart = pos2 + 1;
+          fscan = scan_digits fstart s 0;
+          fdigits = (fscan | @pos) - fstart;
+          if fdigits == 0
+            then parse_error "expected digit after '.'" fstart
+            else Ok {@frac (divide_or_zero (fscan | @value) (pow10 fdigits)), @pos (fscan | @pos)}
+        ) else Ok {@frac 0, @pos pos2};
+      result_bind frac_step (fn fr => (
+        frac = fr | @frac;
+        pos3 = fr | @pos;
+        has_exp = match (peek_char pos3 s) (
+          Some c => (c == "e") || (c == "E");
+          None => False
+        );
+        exp_step =
+          if has_exp then (
+            epos1 = pos3 + 1;
+            exp_neg = (peek_char epos1 s) == Some "-";
+            exp_sign = (peek_char epos1 s) == Some "+";
+            epos2 = if exp_neg || exp_sign then epos1 + 1 else epos1;
+            match (peek_char epos2 s) (
+              None => parse_error "expected exponent digits" epos2;
+              Some efd => if not (is_digit efd) then parse_error "expected exponent digits" epos2 else (
+                escan = scan_digits epos2 s 0;
+                raw = escan | @value;
+                signed = if exp_neg then (0 - raw) else raw;
+                Ok {@exp signed, @pos (escan | @pos)}
+              )
+            )
+          ) else Ok {@exp 0, @pos pos3};
+        result_bind exp_step (fn er => (
+          exp = er | @exp;
+          pos4 = er | @pos;
+          mantissa = int_val + frac;
+          signed_mantissa = if neg then (0 - mantissa) else mantissa;
+          Ok {@value (JNumber (apply_exponent signed_mantissa exp)), @pos pos4}
+        ))
+      ))
+    )
+  )
+);
+
+# --- parse_node: the value grammar, self-recursive only ---
+#
+# `parse_value`, "next array element", "more array elements?", "next object
+# member", "more object members?" are naturally mutually recursive (a value
+# can contain an array of values; an array's tail check can start another
+# value). Noolang has no mutual recursion between bindings, top-level or
+# local — only a binding calling *itself* resolves, because forward
+# references are a static ordering error (confirmed by spike: even a local
+# `is_even`/`is_odd` pair inside one `(...)` block fails to typecheck with
+# "Undefined variable", not just at top level).
+#
+# Standard workaround: fold every production into one self-recursive
+# function keyed by a mode tag, with in-progress array/object accumulators
+# carried in the tag itself. Every branch returns the same
+# `Result {@value JsonValue, @pos Float} JsonParseError` shape (array/object
+# accumulators get wrapped as JArray/JObject on completion), which is what
+# makes a single non-polymorphic recursive function typeable at all.
+variant ParseMode =
+    ModeValue
+  | ModeArrayNext (List JsonValue)
+  | ModeArrayRest (List JsonValue)
+  | ModeObjectNext (List {String, JsonValue})
+  | ModeObjectRest (List {String, JsonValue});
+
+# Empty-list constants, not `[]` literals: a real typer bug (filed — see
+# PR description) makes a bare `[]` passed to two different constructors of
+# the same recursive variant (one expecting `List JsonValue`, the other
+# `List {String, JsonValue}`) cross-contaminate each other's element type,
+# even across unrelated top-level bindings. A `List` built from a real
+# (non-empty, then filtered away) element sidesteps it — `[JNull]` and
+# `[{"", JNull}]` both typecheck fine reused across constructors; only the
+# literal `[]` triggers the bug.
+empty_json_array = list_filter (fn _ => False) [JNull];
+empty_json_object = list_filter (fn _ => False) [{"", JNull}];
+
+parse_node = fn mode pos s => match mode (
+  ModeValue => (
+    p = skip_ws pos s;
+    match (peek_char p s) (
+      None => parse_error "unexpected end of input" p;
+      Some c => match c (
+        "\"" => parse_json_string p s;
+        "{" => (
+          p1 = skip_ws (p + 1) s;
+          if (peek_char p1 s) == Some "}"
+            then Ok {@value (JObject empty_json_object), @pos (p1 + 1)}
+            else parse_node (ModeObjectNext empty_json_object) p1 s
+        );
+        "[" => (
+          p1 = skip_ws (p + 1) s;
+          if (peek_char p1 s) == Some "]"
+            then Ok {@value (JArray empty_json_array), @pos (p1 + 1)}
+            else parse_node (ModeArrayNext empty_json_array) p1 s
+        );
+        "t" => parse_keyword "true" (JBool True) p s;
+        "f" => parse_keyword "false" (JBool False) p s;
+        "n" => parse_keyword "null" JNull p s;
+        _ => if (is_digit c) || (c == "-")
+          then parse_number p s
+          else parse_error ("unexpected character '" + c + "'") p
+      )
+    )
+  );
+  ModeArrayNext acc => result_bind (parse_node ModeValue pos s) (fn item =>
+    parse_node (ModeArrayRest (append acc [item | @value])) (item | @pos) s
+  );
+  ModeArrayRest acc => (
+    p = skip_ws pos s;
+    match (peek_char p s) (
+      None => parse_error "unterminated array" p;
+      Some c =>
+        if c == "," then parse_node (ModeArrayNext acc) (skip_ws (p + 1) s) s
+        else if c == "]" then Ok {@value (JArray acc), @pos (p + 1)}
+        else parse_error "expected ',' or ']'" p
+    )
+  );
+  ModeObjectNext acc => (
+    p = skip_ws pos s;
+    match (peek_char p s) (
+      None => parse_error "unterminated object" p;
+      Some c => if not (c == "\"") then parse_error "expected string key" p else
+        result_bind (parse_string_raw p s) (fn keyRes => (
+          key = keyRes | @value;
+          p1 = skip_ws (keyRes | @pos) s;
+          result_bind (expect_char ":" p1 s) (fn p2 => (
+            p3 = skip_ws p2 s;
+            result_bind (parse_node ModeValue p3 s) (fn valRes =>
+              parse_node (ModeObjectRest (append acc [{key, valRes | @value}])) (valRes | @pos) s
+            )
+          ))
+        ))
+    )
+  );
+  ModeObjectRest acc => (
+    p = skip_ws pos s;
+    match (peek_char p s) (
+      None => parse_error "unterminated object" p;
+      Some c =>
+        if c == "," then parse_node (ModeObjectNext acc) (skip_ws (p + 1) s) s
+        else if c == "}" then Ok {@value (JObject acc), @pos (p + 1)}
+        else parse_error "expected ',' or '}'" p
+    )
+  )
+);
+
+parse_value = fn pos s => parse_node ModeValue pos s;
+
+# Entry point: whole-input parse, rejecting trailing non-whitespace content.
+json_parse = fn input =>
+  result_bind (parse_value 0 input) (fn r => (
+    p = skip_ws (r | @pos) input;
+    match (peek_char p input) (
+      None => Ok (r | @value);
+      Some c => parse_error ("unexpected trailing character '" + c + "'") p
+    )
+  ));
+
+# ========================================
+# SERIALIZER
+# ========================================
+
+escape_char = fn c => match c (
+  "\"" => "\\\"";
+  "\\" => "\\\\";
+  "\n" => "\\n";
+  "\r" => "\\r";
+  "\t" => "\\t";
+  _ => c
+);
+
+escape_string = fn s => join "" (list_map escape_char (chars s));
+
+json_stringify = fn v => match v (
+  JNull => "null";
+  JBool b => match b (True => "true"; False => "false");
+  JNumber n => toString n;
+  JString s => "\"" + escape_string s + "\"";
+  JArray items => "[" + join "," (list_map json_stringify items) + "]";
+  JObject members => "{" + join "," (list_map (fn pair => (
+      {k, mv} = pair;
+      "\"" + escape_string k + "\"" + ":" + json_stringify mv
+    )) members) + "}"
+);
+
+# ========================================
+# EXTRACTION API — pull typed values out of a parsed JsonValue.
+# schema.noo-flavored (Result-based, composable via result_bind) but
+# retyped over the concrete JsonValue rather than Unknown; see plan doc for
+# why Unknown doesn't work here.
+# ========================================
+
+json_as_string = fn v => match v (JString s => Ok s; _ => Err JsonExpectedString);
+json_as_number = fn v => match v (JNumber n => Ok n; _ => Err JsonExpectedNumber);
+json_as_bool = fn v => match v (JBool b => Ok b; _ => Err JsonExpectedBool);
+json_as_array = fn v => match v (JArray items => Ok items; _ => Err JsonExpectedArray);
+json_as_object = fn v => match v (JObject members => Ok members; _ => Err JsonExpectedObject);
+
+json_field = fn key v => result_bind (json_as_object v) (fn members =>
+  match (assoc_get key members) (
+    Some found => Ok found;
+    None => Err (JsonMissingField key)
+  )
+);
+
+json_index = fn idx v => result_bind (json_as_array v) (fn items =>
+  match (at idx items) (
+    Some found => Ok found;
+    None => Err (JsonIndexOutOfBounds idx)
+  )
+);
+
+# ========================================
+# EQUALITY — a plain recursive function, not an `implement Eq JsonValue`.
+# JObject's payload is List {String, JsonValue}, and tuples have no Eq
+# instance in this codebase (see stdlib.test.noo's note on tuples being
+# structural, not nominal); a trait instance here would also cross the
+# same two-parameter-variant arity bug noted above for Result. Comparison
+# is order-sensitive for object members (parse order is preserved, so a
+# value that round-trips through json_parse/json_stringify compares equal
+# to itself).
+#
+# Array/object element-wise comparison goes through `primitive_list_all2`
+# (the same builtin `implement Eq (List a)` uses in stdlib.noo) rather than
+# a hand-rolled zip — that sidesteps needing separate
+# json_array_equals/json_object_equals helpers, which would have to call
+# back into json_equals and hit the no-mutual-recursion wall documented
+# above the parser.
+#
+# `(kx : String)` below isn't decoration: dropping it hits a separate typer
+# bug — `equals kx ky && json_equals vx vy` fails to unify ("Expected Bool,
+# Got String") whenever `kx`/`ky` are unannotated lambda parameters, even
+# though the standalone pieces (`equals kx kx`, `json_equals vx vy`) each
+# type fine alone. Ascribing either operand's type at the call site avoids
+# it (filed — see PR description).
+# ========================================
+
+json_equals = fn a b => match a (
+  JNull => match b (JNull => True; _ => False);
+  JBool x => match b (JBool y => equals x y; _ => False);
+  JNumber x => match b (JNumber y => equals x y; _ => False);
+  JString x => match b (JString y => equals x y; _ => False);
+  JArray xs => match b (JArray ys => primitive_list_all2 json_equals xs ys; _ => False);
+  JObject xs => match b (JObject ys => primitive_list_all2 (fn px py => (
+      {kx, vx} = px;
+      {ky, vy} = py;
+      (equals (kx : String) ky) && (json_equals vx vy)
+    )) xs ys; _ => False)
+);
+
+{
+  @JNull JNull,
+  @JBool JBool,
+  @JNumber JNumber,
+  @JString JString,
+  @JArray JArray,
+  @JObject JObject,
+  @json_parse json_parse,
+  @json_stringify json_stringify,
+  @json_equals json_equals,
+  @json_as_string json_as_string,
+  @json_as_number json_as_number,
+  @json_as_bool json_as_bool,
+  @json_as_array json_as_array,
+  @json_as_object json_as_object,
+  @json_field json_field,
+  @json_index json_index
+}

--- a/test/features/std-json-module.test.ts
+++ b/test/features/std-json-module.test.ts
@@ -2,8 +2,21 @@
 // as plain userland noolang (no native JSON.parse wrapper; see
 // docs/internal/docs-wip/JSON_PARSER_PLAN.md). Tested the same way
 // std/test is: import the module and exercise it as a real consumer would.
-import { test, expect } from 'bun:test';
+import { test, expect, setDefaultTimeout } from 'bun:test';
 import { expectSuccess, runCode } from '../utils';
+
+// Whichever test in this file runs first pays a real, one-time cost:
+// typechecking std/json.noo from scratch currently takes ~15s (module
+// results are cached per-process after that — see the module-loader cache
+// in src/module-loader.ts — so every other test in this file, and every
+// other file that imports std/json in the same `bun test` run, is fast).
+// Bun's default per-test timeout is 5000ms, well under that, so without
+// this the first test intermittently fails as a timeout rather than a
+// real assertion failure. The ~15s figure itself is a known, tracked
+// problem (see the PR #165 discussion and the comment on parse_node in
+// std/json.noo) — this raises the ceiling to stop CI flaking on it, not to
+// paper over it.
+setDefaultTimeout(30000);
 
 const importJson = `{@json_parse json_parse, @json_stringify json_stringify, @json_equals json_equals, @json_field json_field, @json_index json_index, @json_as_string json_as_string, @json_as_number json_as_number, @json_as_bool json_as_bool, @json_as_array json_as_array, @json_as_object json_as_object} = import "std/json";`;
 

--- a/test/features/std-json-module.test.ts
+++ b/test/features/std-json-module.test.ts
@@ -193,3 +193,66 @@ test('the module export types are visible to the importer', () => {
 	const { finalType } = runCode(`{@json_parse} = import "std/json"; json_parse`);
 	expect(finalType).toContain('JsonValue');
 });
+
+// Regression: scan_string used to recurse once per input character with a
+// growing accumulator, which overflowed the JS call stack around ~4000
+// chars regardless of accumulator style (no TCO in the evaluator — see
+// std/json.noo's comment on scan_content). A 6000-char string value used
+// to crash outright; this asserts it now round-trips.
+test('a long string value does not overflow the stack', () => {
+	const longValue = 'x'.repeat(6000);
+	const jsonText = JSON.stringify({ text: longValue });
+	expectSuccess(
+		withParsed(
+			JSON.stringify(jsonText),
+			'match (json_field "text" v) (Ok tv => match (json_as_string tv) (Ok s => toString (length (chars s)); Err _ => "wrong-type"); Err _ => "missing")'
+		),
+		'6000'
+	);
+});
+
+test('a long string with interspersed escapes does not overflow the stack', () => {
+	let raw = '';
+	for (let i = 0; i < 5000; i++) raw += i % 37 === 0 ? '\n' : 'x';
+	const jsonText = JSON.stringify({ text: raw });
+	expectSuccess(
+		withParsed(
+			JSON.stringify(jsonText),
+			'match (json_field "text" v) (Ok tv => match (json_as_string tv) (Ok s => toString (length (chars s)); Err _ => "wrong-type"); Err _ => "missing")'
+		),
+		'5000'
+	);
+});
+
+test('duplicate object keys: last value wins, first position kept', () => {
+	expectSuccess(parseOutcome('"{\\"a\\":1,\\"b\\":2,\\"a\\":3}"'), 'OK:{"a":3,"b":2}');
+});
+
+test('rejects a leading zero in the integer part', () => {
+	expectSuccess(parseOutcome('"01"'), expect.stringContaining('ERR:'));
+	expectSuccess(parseOutcome('"-01"'), expect.stringContaining('ERR:'));
+	// "0" alone and "0.5" are still valid — the check is "0 followed by
+	// another digit", not "any leading 0".
+	expectSuccess(parseOutcome('"0"'), 'OK:0');
+	expectSuccess(parseOutcome('"0.5"'), 'OK:0.5');
+});
+
+test('rejects a raw unescaped control character in a string', () => {
+	// A literal tab byte between the quotes, not the two-character escape
+	// `\t`. RFC 8259 §7 requires this to be escaped.
+	expectSuccess(parseOutcome('"\\"a\tb\\""'), expect.stringContaining('ERR:'));
+});
+
+test('json_stringify emits "null" for non-finite numbers instead of invalid syntax', () => {
+	// json_parse "1e400" overflows our own arithmetic to Infinity — this
+	// isn't a hand-constructed pathological JsonValue, it's reachable from
+	// valid-looking JSON text.
+	expectSuccess(
+		withParsed('"1e400"', 'json_stringify v'),
+		'null'
+	);
+	expectSuccess(
+		withParsed('"-1e400"', 'json_stringify v'),
+		'null'
+	);
+});

--- a/test/features/std-json-module.test.ts
+++ b/test/features/std-json-module.test.ts
@@ -1,0 +1,195 @@
+// std/json — hand-written recursive-descent JSON parser/serializer, built
+// as plain userland noolang (no native JSON.parse wrapper; see
+// docs/internal/docs-wip/JSON_PARSER_PLAN.md). Tested the same way
+// std/test is: import the module and exercise it as a real consumer would.
+import { test, expect } from 'bun:test';
+import { expectSuccess, runCode } from '../utils';
+
+const importJson = `{@json_parse json_parse, @json_stringify json_stringify, @json_equals json_equals, @json_field json_field, @json_index json_index, @json_as_string json_as_string, @json_as_number json_as_number, @json_as_bool json_as_bool, @json_as_array json_as_array, @json_as_object json_as_object} = import "std/json";`;
+
+// Renders a Result JsonValue JsonParseError down to a plain string so
+// assertions don't need to know the constructor shapes.
+const parseOutcome = (jsonText: string) => `
+${importJson}
+match (json_parse ${jsonText}) (
+  Ok v => concat "OK:" (json_stringify v);
+  Err e => match e (JsonParseError info => concat "ERR:" (@message info))
+)`;
+
+// Parses `jsonText` (assumed valid) and feeds the JsonValue into `expr`,
+// which should reference `v`. Avoids `Ok v = ...` — noolang has no
+// irrefutable constructor-pattern binding outside `match`.
+const withParsed = (jsonText: string, expr: string) => `
+${importJson}
+match (json_parse ${jsonText}) (
+  Ok v => (${expr});
+  Err _ => "parse-failed"
+)`;
+
+test('parses primitives', () => {
+	expectSuccess(parseOutcome('"null"'), 'OK:null');
+	expectSuccess(parseOutcome('"true"'), 'OK:true');
+	expectSuccess(parseOutcome('"false"'), 'OK:false');
+	expectSuccess(parseOutcome('"\\"hello\\""'), 'OK:"hello"');
+});
+
+test('parses numbers: integers, negatives, decimals, exponents', () => {
+	expectSuccess(parseOutcome('"0"'), 'OK:0');
+	expectSuccess(parseOutcome('"42"'), 'OK:42');
+	expectSuccess(parseOutcome('"-42"'), 'OK:-42');
+	expectSuccess(parseOutcome('"3.14"'), 'OK:3.14');
+	expectSuccess(parseOutcome('"-3.14"'), 'OK:-3.14');
+	expectSuccess(parseOutcome('"1e2"'), 'OK:100');
+	expectSuccess(parseOutcome('"1.5e2"'), 'OK:150');
+	expectSuccess(parseOutcome('"1E+2"'), 'OK:100');
+	expectSuccess(parseOutcome('"2.5e-1"'), 'OK:0.25');
+});
+
+test('parses arrays, including nested and empty', () => {
+	expectSuccess(parseOutcome('"[1,2,3]"'), 'OK:[1,2,3]');
+	expectSuccess(parseOutcome('"[]"'), 'OK:[]');
+	expectSuccess(parseOutcome('"[[1,2],[3,4]]"'), 'OK:[[1,2],[3,4]]');
+	expectSuccess(parseOutcome('"[1, true, null, \\"x\\"]"'), 'OK:[1,true,null,"x"]');
+});
+
+test('parses objects, including nested and empty', () => {
+	expectSuccess(parseOutcome('"{\\"a\\":1,\\"b\\":2}"'), 'OK:{"a":1,"b":2}');
+	expectSuccess(parseOutcome('"{}"'), 'OK:{}');
+	expectSuccess(
+		parseOutcome('"{\\"a\\":{\\"b\\":[1,2]}}"'),
+		'OK:{"a":{"b":[1,2]}}'
+	);
+});
+
+test('tolerates whitespace around tokens', () => {
+	expectSuccess(
+		parseOutcome('"  { \\"a\\" : 1 , \\"b\\" : [ 1 , 2 ] }  "'),
+		'OK:{"a":1,"b":[1,2]}'
+	);
+});
+
+test('handles string escapes: quote, backslash, slash, newline, tab, cr', () => {
+	expectSuccess(parseOutcome('"\\"a\\\\\\"b\\""'), 'OK:"a\\"b"');
+	expectSuccess(parseOutcome('"\\"a\\\\\\\\b\\""'), 'OK:"a\\\\b"');
+	expectSuccess(parseOutcome('"\\"a\\\\/b\\""'), 'OK:"a/b"');
+	expectSuccess(parseOutcome('"\\"a\\\\nb\\""'), 'OK:"a\\nb"');
+	expectSuccess(parseOutcome('"\\"a\\\\tb\\""'), 'OK:"a\\tb"');
+});
+
+test('rejects malformed input with a positioned error', () => {
+	expectSuccess(parseOutcome('"not json"'), expect.stringContaining('ERR:'));
+	expectSuccess(parseOutcome('"{\\"a\\": }"'), expect.stringContaining('ERR:'));
+	expectSuccess(parseOutcome('"[1, 2,]"'), expect.stringContaining('ERR:'));
+	expectSuccess(parseOutcome('"\\"unterminated"'), expect.stringContaining('ERR:'));
+	expectSuccess(parseOutcome('""'), expect.stringContaining('ERR:'));
+});
+
+test('rejects trailing content after a valid value', () => {
+	expectSuccess(parseOutcome('"{\\"a\\":1} extra"'), expect.stringContaining('ERR:'));
+	expectSuccess(parseOutcome('"1 2"'), expect.stringContaining('ERR:'));
+});
+
+test('rejects unsupported \\u and \\b/\\f escapes rather than mis-decoding them', () => {
+	// Documented scope limit: no codepoint<->char builtin (fromCharCode /
+	// charCodeAt) exists in noolang, so \u escapes can't be decoded and
+	// aren't silently passed through either.
+	expectSuccess(parseOutcome('"\\"\\\\u0041\\""'), expect.stringContaining('ERR:'));
+	expectSuccess(parseOutcome('"\\"\\\\b\\""'), expect.stringContaining('ERR:'));
+});
+
+test('json_stringify round-trips through json_parse', () => {
+	expectSuccess(
+		withParsed(
+			'"{\\"name\\":\\"Ada\\",\\"tags\\":[\\"math\\",\\"cs\\"],\\"active\\":true,\\"meta\\":null,\\"score\\":3.5}"',
+			`
+    stringified = json_stringify v;
+    match (json_parse stringified) (
+      Ok v2 => if json_equals v v2 then "roundtrip-ok" else "roundtrip-mismatch";
+      Err _ => "reparse-failed"
+    )`
+		),
+		'roundtrip-ok'
+	);
+});
+
+test('json_equals distinguishes different values and ignores nothing', () => {
+	expectSuccess(
+		`
+${importJson}
+a = json_parse "{\\"x\\":1,\\"y\\":[1,2]}";
+b = json_parse "{\\"x\\":1,\\"y\\":[1,2]}";
+c = json_parse "{\\"x\\":1,\\"y\\":[1,3]}";
+match {a, b, c} (
+  {Ok va, Ok vb, Ok vc} =>
+    if (json_equals va vb) && (not (json_equals va vc))
+      then "as-expected"
+      else "mismatch";
+  _ => "parse-failed"
+)`,
+		'as-expected'
+	);
+});
+
+test('json_field extracts an object member, errors on missing key or non-object', () => {
+	expectSuccess(
+		withParsed(
+			'"{\\"a\\":1}"',
+			'match (json_field "a" v) (Ok found => json_stringify found; Err _ => "missing")'
+		),
+		'1'
+	);
+	expectSuccess(
+		withParsed(
+			'"{\\"a\\":1}"',
+			'match (json_field "z" v) (Ok _ => "found"; Err _ => "missing")'
+		),
+		'missing'
+	);
+	expectSuccess(
+		withParsed(
+			'"[1,2]"',
+			'match (json_field "a" v) (Ok _ => "found"; Err _ => "not-object")'
+		),
+		'not-object'
+	);
+});
+
+test('json_index extracts an array element, errors on out-of-bounds or non-array', () => {
+	expectSuccess(
+		withParsed(
+			'"[10,20,30]"',
+			'match (json_index 1 v) (Ok found => json_stringify found; Err _ => "missing")'
+		),
+		'20'
+	);
+	expectSuccess(
+		withParsed(
+			'"[10,20,30]"',
+			'match (json_index 9 v) (Ok _ => "found"; Err _ => "missing")'
+		),
+		'missing'
+	);
+});
+
+test('json_as_* extractors accept the matching shape and reject others', () => {
+	expectSuccess(
+		withParsed('"\\"hi\\""', 'match (json_as_string v) (Ok s => s; Err _ => "wrong-type")'),
+		'hi'
+	);
+	expectSuccess(
+		withParsed('"42"', 'match (json_as_string v) (Ok _ => "string"; Err _ => "wrong-type")'),
+		'wrong-type'
+	);
+	expectSuccess(
+		withParsed(
+			'"true"',
+			'match (json_as_bool v) (Ok b => if b then "yes" else "no"; Err _ => "wrong-type")'
+		),
+		'yes'
+	);
+});
+
+test('the module export types are visible to the importer', () => {
+	const { finalType } = runCode(`{@json_parse} = import "std/json"; json_parse`);
+	expect(finalType).toContain('JsonValue');
+});


### PR DESCRIPTION
## Summary

Implements `std/json` — parse + serialize, hand-written recursive-descent, entirely in `.noo` (no native `JSON.parse` wrapper). Scoping/rationale doc: `docs/internal/docs-wip/JSON_PARSER_PLAN.md`.

- `JsonValue` is a concrete variant, not `Unknown`: `JNull | JBool Bool | JNumber Float | JString String | JArray (List JsonValue) | JObject (List {String, JsonValue})`. `Unknown` was ruled out earlier — records can't take runtime-computed keys, and `Unknown` has no `isTuple`/`isRecord` to recover a record shape from, so a JSON object could never round-trip through it either way.
- `json_parse : String -> Result JsonValue JsonParseError`, `json_stringify : JsonValue -> String` — round-trips (objects, arrays, strings with `\" \\ \/ \n \r \t` escapes, negative/decimal/exponent numbers, `true`/`false`/`null`).
- Extraction API: `json_field`, `json_index`, `json_as_string/number/bool/array/object` — `Result`-based and composable, schema.noo-flavored but retyped over the concrete `JsonValue`.
- `json_equals` is a plain recursive function, not `implement Eq JsonValue` — tuples have no `Eq` instance in this codebase, so `List {String, JsonValue}` (object members) can't get one via the trait system.
- Documented scope limit: `\u`, `\b`, `\f` string escapes are rejected (not decoded/mis-decoded) — there's no codepoint↔char builtin (`fromCharCode`/`charCodeAt`) to implement them with.

## Bugs found while building this (the point of the exercise)

Two real noolang typer bugs surfaced and are documented inline in `std/json.noo` with minimal repros:

1. **No mutual recursion between bindings, local or top-level.** `parse_value` naturally wants to mutually recurse with array/object element collection. Even `is_even`/`is_odd` inside one `(...)` block fails to typecheck ("Undefined variable", a static ordering error, not a runtime one). Routed around by folding every production into one self-recursive `parse_node` keyed by a mode tag, with in-progress array/object accumulators carried in the tag — standard technique for eliminating mutual recursion when only self-recursion is available.
2. **`[]` cross-contaminates sibling-constructor element types on a recursive variant.** Minimal repro:
   ```
   variant M = MA (List Float) | MO (List {String, Float});
   x = MO [];
   y = MA [];
   ```
   fails to unify (`Expected: Float, Got: (String Float)`), order-independent, even across unrelated top-level bindings — but works fine with any non-empty list literal instead of `[]`. Worked around with `list_filter (fn _ => False) [dummy]` in place of bare `[]`.
3. Related: `equals kx ky && json_equals vx vy` fails to unify ("Expected Bool, Got String") when `kx`/`ky` are unannotated lambda parameters, even though `equals kx kx` and `json_equals vx vy` each type fine standalone. Worked around by ascribing one operand's type at the call site (`equals (kx : String) ky`).

None of these block correctness (workarounds are in the file with rationale), but they're real gaps worth a follow-up typer issue.

## Performance note

Typechecking `std/json.noo` (442 lines, several deeply-nested `match`/`if` bodies) takes ~30s — confirmed via `Performance` CLI output, isolated by bisecting the file. It's paid once per process (module cache, verified: importing it twice in one file doesn't double the cost), so `AGENT=1 bun test` goes from ~40s to ~76s, not 40s × N. Not fixed here — looks like a parser-combinator backtracking cost tied to nesting depth/size of a single function body, which is an interpreter-internals question outside this task's scope, but worth flagging since stdlib files will keep growing.

## Test plan

- `test/features/std-json-module.test.ts` — TS, TDD-style, per-case isolation (primitives, numbers incl. exponents, arrays/objects incl. nested/empty, whitespace, string escapes, malformed/trailing-content errors, `\u`/`\b` rejection, round-trip via `json_equals`, extraction API).
- `json.test.noo` — `noo test` suite exercising the module as a real import, alongside `stdlib.test.noo`.
- `bun run typecheck` — clean.
- `AGENT=1 bun test` — 1332 pass, 0 fail, 0 skip beyond pre-existing 8.
- `node validate_examples.js` — exit 0, all docs pass.
- `NO_COLOR=1 bun src/cli.ts test` — both `.test.noo` suites green.