### PR TITLE
Fix empty-list type-variable collision in typeList

### DIFF
--- a/src/typer/__tests__/empty-list-typevar-collision.test.ts
+++ b/src/typer/__tests__/empty-list-typevar-collision.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'bun:test';
+import { runCode } from '../../../test/utils';
+
+// Regression test for docs/internal/docs-wip/EMPTY_LIST_TYPEVAR_COLLISION_BUG.md
+// (retired once this fix landed).
+//
+// typeList's empty-list case hardcoded typeVariable('a') instead of minting a
+// fresh one via freshTypeVariable(state). Because state.substitution is a
+// single map keyed by variable *name* and threaded through the whole program,
+// every bare `[]` literal produced a type variable literally named 'a', so
+// two unrelated `[]` literals in different top-level bindings could collide:
+// unifying the first one against its constructor's payload type left a
+// stale `a -> <that type>` binding in the shared substitution, which then
+// broke unification for the second, unrelated `[]`.
+describe('empty list type-variable collision', () => {
+	it('does not let one bare [] poison a differently-shaped bare [] elsewhere', () => {
+		const code = `
+			variant M = MA (List Float) | MO (List {String, Float});
+			x = MO [];
+			y = MA [];
+			x
+		`;
+		// Should typecheck without throwing "Cannot unify types".
+		expect(() => runCode(code)).not.toThrow();
+	});
+
+	it('is order-independent (swapping the definitions also typechecks)', () => {
+		const code = `
+			variant M = MA (List Float) | MO (List {String, Float});
+			y = MA [];
+			x = MO [];
+			x
+		`;
+		expect(() => runCode(code)).not.toThrow();
+	});
+});

--- a/src/typer/type-inference.ts
+++ b/src/typer/type-inference.ts
@@ -1450,7 +1450,8 @@ export const typeList = (
 ): TypeResult => {
 	if (expr.elements.length === 0) {
 		// Empty list - we can't infer the element type
-		return createPureTypeResult(listTypeWithElement(typeVariable('a')), state);
+		const [elementType, freshState] = freshTypeVariable(state);
+		return createPureTypeResult(listTypeWithElement(elementType), freshState);
 	}
 
 	// Infer the type from the first element


### PR DESCRIPTION
## Summary
- `typeList`'s empty-list case hardcoded `typeVariable('a')` instead of `freshTypeVariable(state)` like every sibling placeholder-type site in `src/typer/type-inference.ts`. Because `state.substitution` is a single map keyed by variable name and threaded through the whole program, two unrelated bare `[]` literals in different top-level bindings could collide on the shared name `a` and poison each other's unification (order-dependent on which binding ran first).
- Repo-wide grep for the same `typeVariable('<literal-name>')` anti-pattern outside `builtins.ts` (where hardcoded names are intentional TypeScheme quantified vars, freshened per instantiation, not a bug) found no other instances.
- Retires `docs/internal/docs-wip/EMPTY_LIST_TYPEVAR_COLLISION_BUG.md`, which diagnosed this and verified the fix without landing it.

## Test plan
- [x] New regression test `src/typer/__tests__/empty-list-typevar-collision.test.ts` — confirmed red against unfixed code (reproduces the doc's exact `Cannot unify types: Expected Float, Got (String Float)` error), green after the fix, both definition orders.
- [x] `bun run typecheck` clean
- [x] `AGENT=1 bun test` — 1319 pass, 0 fail
- [x] `node validate_examples.js` — exit 0, all docs pass
- [x] `bun src/cli.ts test stdlib.test.noo` — 27 pass, 0 fail
- [x] `NO_COLOR=1 bun src/cli.ts --types` spot-checks: `[]` → `List a`, `[1,2,3]` → `List Float`, branch fn → `Bool -> List Float` — unchanged from pre-fix, confirming no regression to ordinary List inference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)