### PR TITLE
Investigate TS7 typescript-eslint alias fix: broken under bun, keep 6.0.3 cap

### DIFF
--- a/docs/internal/adrs/0002-typescript-6-cap.md
+++ b/docs/internal/adrs/0002-typescript-6-cap.md
@@ -1,0 +1,50 @@
+# 2. Cap `typescript` at 6.0.3 until one of three triggers fires
+
+Date: 2026-08-01
+
+## Status
+
+Accepted
+
+## Context
+
+TS7 dropped the programmatic compiler API; `typescript-eslint` refuses to
+run under it. PR #169 capped `typescript` at `^6.0.3` — newest version that
+both `tsc` and `typescript-eslint` accept — as a stopgap.
+
+Microsoft's documented fix is `@typescript/typescript6`, a TS6-API compat
+shim, installed alongside real TS7 via npm dependency aliasing (real `tsc`
+under one local name, `require('typescript')` resolving to the shim under
+another, so `typescript-eslint` needs no code change). Investigated in PR
+#173: the manifest works correctly under plain `npm install`, but bun 1.2.19
+mis-resolves the shim's own transitive `npm:` alias, silently collapsing it
+onto itself (`require('typescript')` ends up empty — no `createProgram`,
+shim non-functional). Confirmed via `bun.lock` inspection, a cache-cleared
+reinstall, and a bun `overrides` attempt; none fixed it. Full repro and
+evidence: `docs/internal/docs-wip/TS7_ALIAS_BUN_BUG.md`.
+
+## Decision
+
+Stay on `typescript: ^6.0.3` until any of:
+
+1. **Bun fixes nested `npm:` alias resolution.** Re-run the exact repro in
+   `TS7_ALIAS_BUN_BUG.md` against the new bun version first — don't assume
+   it's fixed from a changelog entry alone, and don't assume bun's behavior
+   elsewhere is unchanged just because this one bug is gone.
+2. **`typescript-eslint` ships native TS7 support**, removing the need for
+   the shim (and the alias, and this ADR) entirely. Re-check by attempting a
+   plain `typescript: ^7.x` bump with no alias.
+3. **The project moves off bun** for installs (npm/pnpm/yarn), where the
+   alias manifest is already confirmed working.
+
+At whichever trigger fires, re-verify the full checklist from PR #169/#173
+(`bun run typecheck`, `bun run typecheck:test`, `AGENT=1 bun test`,
+`node validate_examples.js`, `bun run lint`) rather than trusting that a
+fixed root cause implies a clean upgrade.
+
+## Consequences
+
+- `tsc` itself stays on TS6, forgoing TS7's compiler speedup, until a
+  trigger fires.
+- The investigation is preserved in docs-wip so the alias approach isn't
+  blindly re-attempted; this ADR is the pointer to it.

--- a/docs/internal/docs-wip/TS7_ALIAS_BUN_BUG.md
+++ b/docs/internal/docs-wip/TS7_ALIAS_BUN_BUG.md
@@ -1,0 +1,71 @@
+# TS7 + typescript-eslint via npm dependency aliasing: doesn't work under bun
+
+Investigated 2026-08-01, following up on PR #169's `typescript` cap at `^6.0.3`
+(root cause: `typescript-eslint` refuses to run under TS7's removed
+programmatic compiler API).
+
+## The proposed fix
+
+Microsoft's TS7 announcement documents exactly this problem and ships
+`@typescript/typescript6`, a compat package re-exporting the TS6 API, meant
+to be installed alongside real TS7 via npm dependency aliasing:
+
+```json
+{
+  "devDependencies": {
+    "@typescript/native": "npm:typescript@^7.0.2",
+    "typescript": "npm:@typescript/typescript6@^6.0.2"
+  }
+}
+```
+
+Idea: `tsc` (real, fast, TS7) lives under the local name `@typescript/native`;
+anything that does `require('typescript')` (i.e. typescript-eslint) resolves
+to the TS6-API shim instead. No code changes needed in typescript-eslint.
+
+## Verified: the concept itself is sound
+
+Confirmed in a scratch npm install with this exact manifest:
+
+- `node_modules/.bin/tsc` → `@typescript/native/bin/tsc`, reports `Version
+  7.0.2` (real TS7's own `bin` field is `{"tsc": "./bin/tsc"}`; the shim's is
+  `{"tsc6": "./bin/tsc6"}`, so there's no bin collision).
+- `require('typescript')` under npm returns 2248 keys including a working
+  `createProgram` — i.e. the shim is fully functional there.
+
+## Bun cannot install this manifest correctly — do not adopt
+
+`@typescript/typescript6` itself depends on `"@typescript/old": "npm:
+typescript@^6"` (it needs the *real* TS6 implementation under an internal
+alias; its own `lib/typescript.js` is just `module.exports =
+require("@typescript/old")`).
+
+Under `bun install` (1.2.19), this nested alias resolves wrong: bun's
+lockfile shows `@typescript/old` resolving to `@typescript/typescript6@6.0.2`
+— itself — instead of the real `typescript@^6` package:
+
+```
+"@typescript/old": ["@typescript/typescript6@6.0.2", "", { "dependencies": { "@typescript/old": "npm:typescript@^6" }, ... }]
+```
+
+The root-level override of the literal name `typescript` bleeds into
+transitive resolution of that same literal name elsewhere in the graph, which
+npm scopes correctly and bun does not. Result: `require('typescript')` in the
+installed tree returns an empty object (0 keys, no `createProgram`) — the
+shim is non-functional, so typescript-eslint would still be broken, just
+silently instead of loudly.
+
+Tried and ruled out:
+- Clearing `~/.bun/install/cache` and reinstalling — same result.
+- Adding a bun `"overrides"` entry pointing `@typescript/old` directly at
+  real `typescript@6.0.3` — ignored; identical broken resolution.
+
+This is a bun-specific bug in nested/transitive `npm:` alias resolution, not
+a manifest mistake — the identical `package.json` installs and works
+correctly under plain `npm install`.
+
+## Decision
+
+Keep `typescript` capped at `^6.0.3` (unchanged from PR #169). Re-attempt
+only if a future bun release fixes transitive alias resolution, or if the
+project moves off bun for installs.


### PR DESCRIPTION
## Summary
- Verified Microsoft's documented workaround for typescript-eslint's TS7 incompatibility (`@typescript/typescript6` compat shim installed alongside real TS7 via npm dependency aliasing) — the manifest from their blog post installs and works correctly under plain `npm install` (`tsc` resolves to real TS7, `require('typescript')` resolves to a fully functional TS6-API shim).
- It does **not** work under bun 1.2.19: the shim's own transitive dependency (`@typescript/old` → real `typescript@^6`) gets mis-resolved by bun, collapsing back onto the shim package itself. `require('typescript')` ends up returning an empty object — silently broken, would leave typescript-eslint non-functional. Reproduced with a cleared bun cache and also tried a bun `overrides` entry to force the nested resolution; neither fixed it. Same manifest works under npm, so this is a bun resolution bug, not a mistake in the manifest.
- No code change to `package.json` — falls back to the existing `typescript: ^6.0.3` cap from #169, which is already correct. This PR just files the investigation (`docs/internal/docs-wip/TS7_ALIAS_BUN_BUG.md`) so it isn't re-attempted blind.
- Checked `lsp/extension` separately: it already runs real `typescript@^7.0.2` with no typescript-eslint dependency at all (just `tsc` compile, no lint step there), so it's unaffected either way.

## Verification (clean `rm -rf node_modules && bun install`, on this branch = current main state)
- [x] `bun run typecheck` — clean
- [x] `bun run typecheck:test` — clean
- [x] `AGENT=1 bun test` — 1349 pass, 0 fail
- [x] `node validate_examples.js` — exit 0
- [x] `bun run lint` — runs (doesn't crash), 23 pre-existing findings, same as #169's baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)