### PR TITLE
Beta-reduce parametric type aliases during resolution

### DIFF
--- a/src/typer/type-inference.ts
+++ b/src/typer/type-inference.ts
@@ -1572,6 +1572,28 @@ const resolveTypeAliases = (
 				visited.delete(type.name);
 				return resolved;
 			}
+			if (
+				aliasScheme &&
+				aliasScheme.quantifiedVars.length > 0 &&
+				aliasScheme.quantifiedVars.length === type.args.length
+			) {
+				// Parametric type alias applied to arguments (e.g. `Box Float`).
+				// Beta-reduce: substitute each of the alias's quantified vars in
+				// its stored body with the corresponding (already-resolved)
+				// argument before resolving the result further.
+				visited.add(type.name);
+				const resolvedArgs = type.args.map(arg =>
+					resolveTypeAliases(arg, state, visited)
+				);
+				const substitution = new Map<string, Type>();
+				aliasScheme.quantifiedVars.forEach((param, i) => {
+					substitution.set(param, resolvedArgs[i]);
+				});
+				const beta = substitute(aliasScheme.type, substitution);
+				const resolved = resolveTypeAliases(beta, state, visited);
+				visited.delete(type.name);
+				return resolved;
+			}
 			// If it has arguments, recursively resolve them
 			const resolvedArgs = type.args.map(arg =>
 				resolveTypeAliases(arg, state, visited)

--- a/test/features/user-defined-types.test.ts
+++ b/test/features/user-defined-types.test.ts
@@ -236,4 +236,57 @@ describe('Type Alias Functionality', () => {
         `;
 			expectSuccess(code, '42');
 		});
+
+		test('parametric type alias applied to a concrete type should expand under ascription', () => {
+			// Regression: `Box Float` was treated as an opaque nominal application
+			// instead of being beta-reduced to `{ value: Float }` before unifying
+			// against the inferred record type.
+			const code = `
+            type Box a = {@value a};
+            mkBox = fn v => {@value v};
+            b = (mkBox 42 : Box Float);
+            b | @value
+        `;
+			expectSuccess(code, 42);
+		});
+
+		test('parametric type alias with multiple type params should expand under ascription', () => {
+			const code = `
+            type Pair a b = {@left a, @right b};
+            mkPair = fn l r => {@left l, @right r};
+            p = (mkPair 1 "x" : Pair Float String);
+            p | @right
+        `;
+			expectSuccess(code, 'x');
+		});
+
+		test('nested parametric type aliases should expand under ascription', () => {
+			const code = `
+            type Box a = {@value a};
+            type Wrapper a = {@inner Box a};
+            mkWrapper = fn v => {@inner {@value v}};
+            w = (mkWrapper 42 : Wrapper Float);
+            w | @inner | @value
+        `;
+			expectSuccess(code, 42);
+		});
+
+		test('parametric type alias used without ascription should still infer via ordinary HM', () => {
+			const code = `
+            type Box a = {@value a};
+            mkBox = fn v => {@value v};
+            b = mkBox 42;
+            b | @value
+        `;
+			expectSuccess(code, 42);
+		});
+
+		test('parametric type alias parameter in function position should expand under ascription', () => {
+			const code = `
+            type Transformer a = {(a) -> a};
+            t = ({fn x => x + 1} : Transformer Float);
+            match t ({f} => f 41)
+        `;
+			expectSuccess(code, 42);
+		});
 });


### PR DESCRIPTION
## Summary
- `resolveTypeAliases` treated a parametric alias applied to args (`Box Float`) as opaque instead of substituting args for the alias's quantified vars and resolving the reduced body — so ascriptions like `(x : Box Float)` failed to unify against the underlying record/function shape.
- Fix beta-reduces: substitutes each quantified var with its (already-resolved) argument, then resolves the reduced body further.

## Test plan
- [x] `AGENT=1 bun test test/features/user-defined-types.test.ts` — new regression tests (single/multi-param, nested, function-shaped alias, non-ascribed control case) pass
- [x] Full suite: `AGENT=1 bun test` — 1354 pass, 0 fail
- [x] `bun run typecheck`
- [x] `node validate_examples.js`