### PR TITLE
parser: fix more composite expression locations (if, unary minus, literals, where)

### DIFF
--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -284,13 +284,13 @@ const parseRecordFields: C.Parser<
 // --- Record/Tuple Parsing ---
 const parseRecord = C.map(
 	C.seq(C.punctuation('{'), C.optional(parseRecordFields), C.punctuation('}')),
-	([open, fields, _close]): Expression => {
+	([open, fields, close]): Expression => {
 		const fieldsList = fields || [];
 		if (fieldsList.length === 0) {
 			// Empty braces: unit
 			return {
 				kind: 'unit',
-				location: open.location,
+				location: createLocation(open.location.start, close.location.end),
 			} as UnitExpression;
 		}
 		const allNamed = fieldsList.every(f => f.name[0] !== '@');
@@ -300,14 +300,14 @@ const parseRecord = C.map(
 			return {
 				kind: 'record',
 				fields: fieldsList,
-				location: open.location,
+				location: createLocation(open.location.start, close.location.end),
 			} as RecordExpression;
 		} else if (allPositional) {
 			// All positional fields: tuple
 			return {
 				kind: 'tuple',
 				elements: fieldsList.map(f => f.value),
-				location: open.location,
+				location: createLocation(open.location.start, close.location.end),
 			} as TupleExpression;
 		} else {
 			// Mixed fields: error
@@ -664,7 +664,7 @@ const parseLambdaBodyUnary: C.Parser<Expression> = tokens => {
 						location: minusToken.location,
 					},
 					right: operandResult.value,
-					location: minusToken.location,
+					location: createLocation(minusToken.location.start, operandResult.value.location.end),
 				},
 				remaining: operandResult.remaining,
 			};
@@ -746,12 +746,12 @@ const parseListElements: C.Parser<Expression[]> = tokens => {
 
 const parseList: C.Parser<ListExpression> = C.map(
 	C.seq(C.punctuation('['), C.optional(parseListElements), C.punctuation(']')),
-	([open, elements, _close]) => {
+	([open, elements, close]) => {
 		const elementsList: Expression[] = elements || [];
 		return {
 			kind: 'list',
 			elements: elementsList,
-			location: open.location,
+			location: createLocation(open.location.start, close.location.end),
 		};
 	}
 );
@@ -851,7 +851,7 @@ const parseUnary: C.Parser<Expression> = tokens => {
 						location: minusToken.location,
 					},
 					right: operandResult.value,
-					location: minusToken.location,
+					location: createLocation(minusToken.location.start, operandResult.value.location.end),
 				},
 				remaining: operandResult.remaining,
 			} as const;
@@ -1926,12 +1926,12 @@ const parseWhereExpression: C.Parser<WhereExpression> = C.map(
 		_openParen,
 		definitions,
 		_trailingSemicolons,
-		_closeParen,
+		closeParen,
 	]): WhereExpression => ({
 		kind: 'where',
 		main,
 		definitions,
-		location: main.location,
+		location: createLocation(main.location.start, closeParen.location.end),
 	})
 );
 
@@ -2032,7 +2032,7 @@ const parseIfExpression = C.map(
 			condition,
 			then: thenExpr,
 			else: elseExpr,
-			location: ifKw.location,
+			location: createLocation(ifKw.location.start, elseExpr.location.end),
 		};
 	}
 );

--- a/test/parser-locations.test.ts
+++ b/test/parser-locations.test.ts
@@ -120,4 +120,41 @@ describe('composite expression locations span through the right operand', () => 
 		expect(fn.kind).toBe('function');
 		expect(endCol(fn)).toBe(18);
 	});
+
+	// Found via real corruption: the LSP "infer type annotation" action
+	// spliced text at an `if` expression's reported end, which pointed at
+	// just the `if` keyword — inserting the annotation mid-condition instead
+	// of after the whole if/then/else. Same bug class as the binary/pipeline
+	// sites above, different node kinds that weren't covered by that sweep.
+	test('if/then/else spans through the else branch', () => {
+		expect(endCol(parseExpr('if True then 1 else 22222'))).toBe(26);
+	});
+
+	test('unary minus spans through the operand', () => {
+		expect(endCol(parseExpr('-22222'))).toBe(7);
+	});
+
+	test('unary minus in a lambda body spans through the operand', () => {
+		expect(endCol(parseExpr('fn x => -22222'))).toBe(15);
+	});
+
+	test('record literal spans through the closing brace', () => {
+		expect(endCol(parseExpr('{@a 22222}'))).toBe(11);
+	});
+
+	test('tuple literal spans through the closing brace', () => {
+		expect(endCol(parseExpr('{1, 22222}'))).toBe(11);
+	});
+
+	test('unit literal spans through the closing brace', () => {
+		expect(endCol(parseExpr('{}'))).toBe(3);
+	});
+
+	test('list literal spans through the closing bracket', () => {
+		expect(endCol(parseExpr('[1, 22222]'))).toBe(11);
+	});
+
+	test('where expression spans through its definitions clause', () => {
+		expect(endCol(parseExpr('main where (x = 22222)'))).toBe(23);
+	});
 });


### PR DESCRIPTION
## Summary
- Follow-up to #181, which fixed the binary-operator/pipeline/application location bug but wasn't an exhaustive sweep of the parser.
- Same bug, different node kinds — each built its location from only the first token instead of spanning to the real end:
  - `if`/`then`/`else`: location was just the `if` keyword
  - unary minus (`-x`, desugared to a binary node internally): location was just `-`
  - record/tuple/unit literals: location was just the opening `{`
  - list literals: location was just the opening `[`
  - `where` expressions: location was just the main expression, not through the `where (...)` clause
- Found via real corruption: an LSP code action (#182, WIP) that splices a type annotation at a function body's reported end position hit `pow10 = fn n => if n <= 0 then 1 else 10 * pow10 (n - 1);` in `std/json.noo` and inserted the annotation right after `if` instead of after the whole expression.

## Test plan
- [x] `test/parser-locations.test.ts`: 8 new cases added, confirmed red before the fix, green after (30/30 total in that file)
- [x] `AGENT=1 bun test` — 1430 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] `node validate_examples.js` — all docs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)