### PR TITLE
Remediate LSP harness review feedback

### DIFF
--- a/lsp/extension/package-lock.json
+++ b/lsp/extension/package-lock.json
@@ -14,12 +14,24 @@
         "vscode-uri": "^3.1.0"
       },
       "devDependencies": {
+        "@types/bun": "^1.3.14",
         "@types/node": "^26.1.2",
         "@types/vscode": "1.74.0",
+        "bun-types": "^1.3.14",
         "typescript": "^7.0.2"
       },
       "engines": {
         "vscode": "^1.74.0"
+      }
+    },
+    "node_modules/@types/bun": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@types/bun/-/bun-1.3.14.tgz",
+      "integrity": "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bun-types": "1.3.14"
       }
     },
     "node_modules/@types/node": {
@@ -398,6 +410,16 @@
       },
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/bun-types": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/bun-types/-/bun-types-1.3.14.tgz",
+      "integrity": "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/minimatch": {

--- a/lsp/extension/package.json
+++ b/lsp/extension/package.json
@@ -67,12 +67,14 @@
     "vscode:prepublish": "npm run compile",
     "compile": "tsc -p ./ && tsc -p ./server && tsc -p ./test",
     "watch": "tsc -watch -p ./ & tsc -watch -p ./server",
-    "test": "bun test test",
-    "test:watch": "bun test --watch test"
+    "test": "bun test test/*.test.ts",
+    "test:watch": "bun test --watch test/*.test.ts"
   },
   "devDependencies": {
+    "@types/bun": "^1.3.14",
     "@types/node": "^26.1.2",
     "@types/vscode": "1.74.0",
+    "bun-types": "^1.3.14",
     "typescript": "^7.0.2"
   },
   "dependencies": {

--- a/lsp/extension/package.json
+++ b/lsp/extension/package.json
@@ -65,8 +65,10 @@
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",
-    "compile": "tsc -p ./ && tsc -p ./server",
-    "watch": "tsc -watch -p ./ & tsc -watch -p ./server"
+    "compile": "tsc -p ./ && tsc -p ./server && tsc -p ./test",
+    "watch": "tsc -watch -p ./ & tsc -watch -p ./server",
+    "test": "bun test test",
+    "test:watch": "bun test --watch test"
   },
   "devDependencies": {
     "@types/node": "^26.1.2",

--- a/lsp/extension/server/src/server.ts
+++ b/lsp/extension/server/src/server.ts
@@ -55,7 +55,22 @@ function analysisPath(uri: string, originalPath: string): string {
   if (content === undefined) return originalPath;
   let filePath = materializedPaths.get(uri);
   if (!filePath) {
-    filePath = path.join(tempDirectory, `${materializedPaths.size}.noo`);
+    // Keep the scratch file beside the document whenever its directory exists.
+    // The CLI resolves relative imports from the entry file, so putting every
+    // open document in one unrelated temp directory silently breaks imports.
+    const directory = path.dirname(originalPath);
+    let canWriteBesideDocument = false;
+    try {
+      canWriteBesideDocument = fs.existsSync(directory) && (fs.accessSync(directory, fs.constants.W_OK), true);
+    } catch {
+      canWriteBesideDocument = false;
+    }
+    if (canWriteBesideDocument) {
+      const base = path.basename(originalPath, path.extname(originalPath));
+      filePath = path.join(directory, `.${base}.live-buffer-${process.pid}-${materializedPaths.size}.noo`);
+    } else {
+      filePath = path.join(tempDirectory, `${materializedPaths.size}.noo`);
+    }
     materializedPaths.set(uri, filePath);
   }
   fs.writeFileSync(filePath, content, 'utf8');

--- a/lsp/extension/server/src/server.ts
+++ b/lsp/extension/server/src/server.ts
@@ -23,22 +23,44 @@ import {
   DidOpenTextDocumentParams,
   DidChangeTextDocumentParams,
   DidSaveTextDocumentParams,
+  Connection,
 } from 'vscode-languageserver/node';
 import { URI } from 'vscode-uri';
 import * as fs from 'fs';
 import * as path from 'path';
+import * as os from 'os';
 import { spawnSync } from 'child_process';
 
-const connection = createConnection(ProposedFeatures.all);
+export interface ServerOptions {
+  workspacePath?: string;
+  cliPath?: string;
+  cliRuntime?: string;
+}
+
+export function createServer(connection: Connection, options: ServerOptions = {}): void {
 
 // Very simple in-memory document store (FULL sync)
 const documents = new Map<string, string>(); // key: uri
 
 // Env from client
-const WORKSPACE = process.env.NOOLANG_WORKSPACE || '';
-const CLI_PATH = process.env.NOOLANG_CLI_PATH || path.join(WORKSPACE || '.', 'dist', 'cli.js');
+const WORKSPACE = options.workspacePath || process.env.NOOLANG_WORKSPACE || process.cwd();
+const CLI_PATH = options.cliPath || process.env.NOOLANG_CLI_PATH || path.join(WORKSPACE, 'dist', 'cli.js');
 // bun for live .ts source, node for a built dist bundle (see extension.ts)
-const CLI_RUNTIME = process.env.NOOLANG_CLI_RUNTIME || 'node';
+const CLI_RUNTIME = options.cliRuntime || process.env.NOOLANG_CLI_RUNTIME || 'node';
+const materializedPaths = new Map<string, string>();
+const tempDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'noolang-lsp-'));
+
+function analysisPath(uri: string, originalPath: string): string {
+  const content = documents.get(uri);
+  if (content === undefined) return originalPath;
+  let filePath = materializedPaths.get(uri);
+  if (!filePath) {
+    filePath = path.join(tempDirectory, `${materializedPaths.size}.noo`);
+    materializedPaths.set(uri, filePath);
+  }
+  fs.writeFileSync(filePath, content, 'utf8');
+  return filePath;
+}
 
 function uriToFilePath(uri: string): string | undefined {
   try {
@@ -419,7 +441,7 @@ connection.onDidOpenTextDocument((params: DidOpenTextDocumentParams) => {
   documents.set(uri, content);
   const filePath = uriToFilePath(uri);
   if (filePath) {
-    const diagnostics = getDiagnostics(filePath);
+    const diagnostics = getDiagnostics(analysisPath(uri, filePath));
     connection.sendDiagnostics({ uri, diagnostics });
   }
 });
@@ -434,7 +456,7 @@ connection.onDidChangeTextDocument((params: DidChangeTextDocumentParams) => {
   }
   const filePath = uriToFilePath(uri);
   if (filePath) {
-    const diagnostics = getDiagnostics(filePath);
+    const diagnostics = getDiagnostics(analysisPath(uri, filePath));
     connection.sendDiagnostics({ uri, diagnostics });
   }
 });
@@ -443,7 +465,7 @@ connection.onDidSaveTextDocument((params: DidSaveTextDocumentParams) => {
   const uri = params.textDocument.uri;
   const filePath = uriToFilePath(uri);
   if (filePath) {
-    const diagnostics = getDiagnostics(filePath);
+    const diagnostics = getDiagnostics(analysisPath(uri, filePath));
     connection.sendDiagnostics({ uri, diagnostics });
   }
 });
@@ -470,14 +492,14 @@ connection.onHover((params: HoverParams): Hover | null => {
   const filePath = uriToFilePath(uri);
   if (!filePath) return null;
   const pos = params.position;
-  const type = getPositionType(filePath, pos.line + 1, pos.character + 1);
+  const type = getPositionType(analysisPath(uri, filePath), pos.line + 1, pos.character + 1);
   if (type) {
     return {
       contents: { kind: MarkupKind.Markdown, value: 'Type: ' + type },
       range: Range.create(pos, Position.create(pos.line, pos.character + 1)),
     };
   }
-  const types = getTypeInfo(filePath);
+  const types = getTypeInfo(analysisPath(uri, filePath));
   if (types[0]) {
     return {
       contents: { kind: MarkupKind.Markdown, value: 'Type: ' + simplifyTypeString(types[0]) },
@@ -492,7 +514,7 @@ connection.onDefinition((params: DefinitionParams) => {
   const filePath = uriToFilePath(uri);
   if (!filePath) return null;
   const pos = params.position;
-  const ast = getAstFile(filePath);
+  const ast = getAstFile(analysisPath(uri, filePath));
   if (!ast) return null;
   const name = extractSymbolAtPosition(ast, pos.line + 1, pos.character + 1);
   if (!name) return null;
@@ -506,7 +528,7 @@ connection.onReferences((params: ReferenceParams) => {
   const filePath = uriToFilePath(uri);
   if (!filePath) return [];
   const pos = params.position;
-  const ast = getAstFile(filePath);
+  const ast = getAstFile(analysisPath(uri, filePath));
   if (!ast) return [];
   const name = extractSymbolAtPosition(ast, pos.line + 1, pos.character + 1);
   if (!name) return [];
@@ -519,9 +541,15 @@ connection.onDocumentSymbol((params: DocumentSymbolParams) => {
   const uri = params.textDocument.uri;
   const filePath = uriToFilePath(uri);
   if (!filePath) return [];
-  const ast = getAstFile(filePath);
+  const ast = getAstFile(analysisPath(uri, filePath));
   if (!ast) return [];
   return extractAllSymbols(ast, uri);
 });
 
-connection.listen();
+}
+
+if (require.main === module) {
+  const connection = createConnection(ProposedFeatures.all);
+  createServer(connection);
+  connection.listen();
+}

--- a/lsp/extension/test/README.md
+++ b/lsp/extension/test/README.md
@@ -9,9 +9,9 @@ test/
 ├── harness/
 │   ├── InMemoryTransport.ts    # In-memory MessageReader/MessageWriter
 │   ├── LSPServerHarness.ts     # Test harness main class
-│   └── TestServer.ts           # LSP server logic (mirrors server.ts)
+│   └── TestServer.ts           # Deprecated compatibility re-export of production setup
 ├── fixtures/
-│   └── simple.noo              # Sample .noo file for testing
+│   └── simple.noo              # Sample .noo source used by completion tests
 └── completion.test.ts          # Completion feature tests
 ```
 
@@ -53,14 +53,14 @@ describe('LSP Feature Tests', () => {
    - Server connection: Registers LSP handlers (completion, hover, etc.)
    - Client connection: Sends requests and receives responses
 
-4. **Test Server**: `TestServer.ts` contains the same LSP handler logic as the main `server.ts`, but accepts a custom connection for testing.
+4. **Production server**: `LSPServerHarness.ts` injects its in-memory server connection into `createServer` from `server/src/server.ts`. Tests therefore exercise the shipped handlers; `TestServer.ts` remains only as a compatibility import for older tests.
 
 ## Running Tests
 
 ```bash
 cd lsp/extension
-bun test              # Run all tests (the npm scripts are Bun wrappers)
-bun test --watch      # Run tests in watch mode
+bun test test/*.test.ts        # Run TypeScript tests (the npm scripts are Bun wrappers)
+bun test --watch test/*.test.ts # Run tests in watch mode
 ```
 
 ## Extending to Other Features
@@ -94,6 +94,7 @@ test('reports type errors', async () => {
 
 ## Implementation Notes
 
+- Open documents are synchronized into scratch files beside the original document when possible. This keeps the CLI's relative-import resolution anchored to the document's original directory.
 - The harness uses a small delay (50ms) after starting listeners to ensure both sides are ready
 - Each test should create its own document URIs to avoid conflicts
 - The harness automatically handles initialization (initialize/initialized handshake)

--- a/lsp/extension/test/README.md
+++ b/lsp/extension/test/README.md
@@ -1,0 +1,107 @@
+# LSP Test Harness
+
+A lightweight test harness for the Noolang LSP server that allows testing LSP protocol messages without running a full VSCode instance.
+
+## Structure
+
+```
+test/
+├── harness/
+│   ├── InMemoryTransport.ts    # In-memory MessageReader/MessageWriter
+│   ├── LSPServerHarness.ts     # Test harness main class
+│   └── TestServer.ts           # LSP server logic (mirrors server.ts)
+├── fixtures/
+│   └── simple.noo              # Sample .noo file for testing
+└── completion.test.ts          # Completion feature tests
+```
+
+## Usage
+
+```typescript
+import { LSPServerHarness } from './harness/LSPServerHarness';
+
+describe('LSP Feature Tests', () => {
+  let harness: LSPServerHarness;
+
+  beforeAll(async () => {
+    harness = await LSPServerHarness.create();
+  });
+
+  afterAll(async () => {
+    await harness.close();
+  });
+
+  test('completion request', async () => {
+    const uri = 'file:///test.noo';
+    await harness.openDocument(uri, 'noolang', 'fn x => x');
+
+    const completions = await harness.requestCompletion(uri, 0, 2);
+    expect(completions.length).toBeGreaterThan(0);
+  });
+});
+```
+
+## How It Works
+
+1. **In-Memory Transport**: `InMemoryTransport.ts` implements `MessageReader` and `MessageWriter` interfaces from `vscode-jsonrpc` using in-memory queues instead of network/stdio.
+
+2. **Bidirectional Communication**: Creates paired reader/writer objects that share queues:
+   - `clientWriter` → `serverReader` (client sends requests to server)
+   - `serverWriter` → `clientReader` (server sends responses to client)
+
+3. **Dual Connections**: The harness creates two LSP connections:
+   - Server connection: Registers LSP handlers (completion, hover, etc.)
+   - Client connection: Sends requests and receives responses
+
+4. **Test Server**: `TestServer.ts` contains the same LSP handler logic as the main `server.ts`, but accepts a custom connection for testing.
+
+## Running Tests
+
+```bash
+cd lsp/extension
+bun test              # Run all tests (the npm scripts are Bun wrappers)
+bun test --watch      # Run tests in watch mode
+```
+
+## Extending to Other Features
+
+The harness provides helper methods that can be extended:
+
+- `requestHover(uri, line, character)` - Already available
+- `requestCompletion(uri, line, character)` - Already available
+- `openDocument(uri, languageId, content)` - Already available
+- `changeDocument(uri, content, version)` - Already available
+
+To test a new feature (e.g., diagnostics):
+
+1. Add a helper method to `LSPServerHarness.ts`:
+```typescript
+async requestDiagnostics(uri: string): Promise<Diagnostic[]> {
+  return this.clientConnection.sendRequest('textDocument/diagnostic', { uri });
+}
+```
+
+2. Create a test file (e.g., `diagnostics.test.ts`):
+```typescript
+test('reports type errors', async () => {
+  const uri = 'file:///test.noo';
+  await harness.openDocument(uri, 'noolang', '1 + "string"');
+
+  const diagnostics = await harness.requestDiagnostics(uri);
+  expect(diagnostics.some(d => d.severity === DiagnosticSeverity.Error)).toBe(true);
+});
+```
+
+## Implementation Notes
+
+- The harness uses a small delay (50ms) after starting listeners to ensure both sides are ready
+- Each test should create its own document URIs to avoid conflicts
+- The harness automatically handles initialization (initialize/initialized handshake)
+- Cleanup is handled via the `close()` method which sends shutdown/exit notifications
+
+## Future Improvements
+
+- Add support for testing `publishDiagnostics` notifications
+- Add support for workspace features (workspace/symbol, etc.)
+- Add helper methods for document synchronization (didChange, didSave)
+- Add fixtures for various code scenarios

--- a/lsp/extension/test/completion.test.ts
+++ b/lsp/extension/test/completion.test.ts
@@ -24,59 +24,32 @@ describe('LSP Completion', () => {
 		await harness.close();
 	});
 
-	test('returns completion items for keywords', async () => {
+	test('completion catalogs contain every expected item with its category', async () => {
 		const uri = 'file:///test.noo';
-		const content = FIXTURE;
+		await harness.openDocument(uri, 'noolang', FIXTURE);
 
-		await harness.openDocument(uri, 'noolang', content);
-
-		const completions = await harness.requestCompletion(uri, 0, 1);
-
+		const completions = await harness.requestCompletion(uri, 0, 0);
 		expect(completions).toBeDefined();
 		expect(Array.isArray(completions)).toBe(true);
 		expect(completions.length).toBeGreaterThan(0);
 
-		// Check that we have keywords
-		const keywordItems = completions.filter((item: any) =>
-			item.kind === 14 && EXPECTED_KEYWORDS.includes(item.label)
-		);
-		expect(keywordItems.length).toBeGreaterThan(0);
-	});
+		const labelsByKind = new Map<number, Set<string>>();
+		for (const item of completions) {
+			const labels = labelsByKind.get(item.kind) ?? new Set<string>();
+			labels.add(item.label);
+			labelsByKind.set(item.kind, labels);
+		}
 
-	test('returns completion items for builtins', async () => {
-		const uri = 'file:///test.noo';
-		const content = '';
-
-		await harness.openDocument(uri, 'noolang', content);
-
-		const completions = await harness.requestCompletion(uri, 0, 0);
-
-		expect(completions).toBeDefined();
-		expect(Array.isArray(completions)).toBe(true);
-
-		// Check that we have builtin functions (kind 3 = Function)
-		const builtinItems = completions.filter((item: any) =>
-			item.kind === 3 && EXPECTED_BUILTINS.includes(item.label)
-		);
-		expect(builtinItems.length).toBeGreaterThan(0);
-	});
-
-	test('returns completion items for constructors', async () => {
-		const uri = 'file:///test.noo';
-		const content = '';
-
-		await harness.openDocument(uri, 'noolang', content);
-
-		const completions = await harness.requestCompletion(uri, 0, 0);
-
-		expect(completions).toBeDefined();
-		expect(Array.isArray(completions)).toBe(true);
-
-		// Check that we have constructors (kind 4 = Constructor)
-		const ctorItems = completions.filter((item: any) =>
-			item.kind === 4 && EXPECTED_CONSTRUCTORS.includes(item.label)
-		);
-		expect(ctorItems.length).toBeGreaterThan(0);
+		for (const [kind, expected] of [
+			[14, EXPECTED_KEYWORDS],
+			[4, EXPECTED_CONSTRUCTORS],
+			[3, EXPECTED_BUILTINS],
+		] as const) {
+			const labels = labelsByKind.get(kind) ?? new Set<string>();
+			for (const label of expected) {
+				expect(labels).toContain(label);
+			}
+		}
 	});
 
 	test('completion items have proper structure', async () => {
@@ -95,37 +68,6 @@ describe('LSP Completion', () => {
 		expect(item).toHaveProperty('insertText');
 	});
 
-	test('completion includes all expected keywords', async () => {
-		const uri = 'file:///test.noo';
-		const content = '';
-
-		await harness.openDocument(uri, 'noolang', content);
-
-		const completions = await harness.requestCompletion(uri, 0, 0);
-
-		const labels = completions.map((item: any) => item.label);
-		const expectedKeywords = EXPECTED_KEYWORDS;
-
-		for (const keyword of expectedKeywords) {
-			expect(labels).toContain(keyword);
-		}
-	});
-
-	test('completion includes all expected constructors', async () => {
-		const uri = 'file:///test.noo';
-		const content = '';
-
-		await harness.openDocument(uri, 'noolang', content);
-
-		const completions = await harness.requestCompletion(uri, 0, 0);
-
-		const labels = completions.map((item: any) => item.label);
-		const expectedCtors = EXPECTED_CONSTRUCTORS;
-
-		for (const ctor of expectedCtors) {
-			expect(labels).toContain(ctor);
-		}
-	});
 
 	test('analysis uses the latest in-memory document content', async () => {
 		const uri = 'file:///not-on-disk.noo';
@@ -138,21 +80,6 @@ describe('LSP Completion', () => {
 		expect(JSON.stringify(stringHover)).toContain('String');
 	});
 
-	test('completion includes all expected builtins', async () => {
-		const uri = 'file:///test.noo';
-		const content = '';
-
-		await harness.openDocument(uri, 'noolang', content);
-
-		const completions = await harness.requestCompletion(uri, 0, 0);
-
-		const labels = completions.map((item: any) => item.label);
-		const expectedBuiltins = EXPECTED_BUILTINS;
-
-		for (const builtin of expectedBuiltins) {
-			expect(labels).toContain(builtin);
-		}
-	});
 
 	test('preserves relative imports for opened workspace documents', async () => {
 		const directory = mkdtempSync(join(tmpdir(), 'noolang-lsp-import-'));

--- a/lsp/extension/test/completion.test.ts
+++ b/lsp/extension/test/completion.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Completion tests for Noolang LSP server.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { LSPServerHarness } from './harness/LSPServerHarness';
+
+describe('LSP Completion', () => {
+	let harness: LSPServerHarness;
+
+	beforeAll(async () => {
+		harness = await LSPServerHarness.create();
+	});
+
+	afterAll(async () => {
+		await harness.close();
+	});
+
+	test('returns completion items for keywords', async () => {
+		const uri = 'file:///test.noo';
+		const content = 'f';
+
+		await harness.openDocument(uri, 'noolang', content);
+
+		const completions = await harness.requestCompletion(uri, 0, 1);
+
+		expect(completions).toBeDefined();
+		expect(Array.isArray(completions)).toBe(true);
+		expect(completions.length).toBeGreaterThan(0);
+
+		// Check that we have keywords
+		const keywordItems = completions.filter((item: any) =>
+			item.kind === 14 && ['fn', 'if', 'then', 'else', 'match', 'with', 'variant', 'mut', 'constraint', 'implement'].includes(item.label)
+		);
+		expect(keywordItems.length).toBeGreaterThan(0);
+	});
+
+	test('returns completion items for builtins', async () => {
+		const uri = 'file:///test.noo';
+		const content = '';
+
+		await harness.openDocument(uri, 'noolang', content);
+
+		const completions = await harness.requestCompletion(uri, 0, 0);
+
+		expect(completions).toBeDefined();
+		expect(Array.isArray(completions)).toBe(true);
+
+		// Check that we have builtin functions (kind 3 = Function)
+		const builtinItems = completions.filter((item: any) =>
+			item.kind === 3 && ['head', 'tail', 'map', 'filter', 'reduce', 'length', 'print', 'toString', 'read', 'write', 'log', 'random'].includes(item.label)
+		);
+		expect(builtinItems.length).toBeGreaterThan(0);
+	});
+
+	test('returns completion items for constructors', async () => {
+		const uri = 'file:///test.noo';
+		const content = '';
+
+		await harness.openDocument(uri, 'noolang', content);
+
+		const completions = await harness.requestCompletion(uri, 0, 0);
+
+		expect(completions).toBeDefined();
+		expect(Array.isArray(completions)).toBe(true);
+
+		// Check that we have constructors (kind 4 = Constructor)
+		const ctorItems = completions.filter((item: any) =>
+			item.kind === 4 && ['True', 'False', 'Some', 'None', 'Ok', 'Err'].includes(item.label)
+		);
+		expect(ctorItems.length).toBeGreaterThan(0);
+	});
+
+	test('completion items have proper structure', async () => {
+		const uri = 'file:///test.noo';
+		const content = 'f';
+
+		await harness.openDocument(uri, 'noolang', content);
+
+		const completions = await harness.requestCompletion(uri, 0, 1);
+		expect(completions.length).toBeGreaterThan(0);
+
+		const item = completions[0];
+		expect(item).toHaveProperty('label');
+		expect(item).toHaveProperty('kind');
+		expect(item).toHaveProperty('detail');
+		expect(item).toHaveProperty('insertText');
+	});
+
+	test('completion includes all expected keywords', async () => {
+		const uri = 'file:///test.noo';
+		const content = '';
+
+		await harness.openDocument(uri, 'noolang', content);
+
+		const completions = await harness.requestCompletion(uri, 0, 0);
+
+		const labels = completions.map((item: any) => item.label);
+		const expectedKeywords = ['fn', 'if', 'then', 'else', 'match', 'with', 'variant', 'mut', 'constraint', 'implement'];
+
+		for (const keyword of expectedKeywords) {
+			expect(labels).toContain(keyword);
+		}
+	});
+
+	test('completion includes all expected constructors', async () => {
+		const uri = 'file:///test.noo';
+		const content = '';
+
+		await harness.openDocument(uri, 'noolang', content);
+
+		const completions = await harness.requestCompletion(uri, 0, 0);
+
+		const labels = completions.map((item: any) => item.label);
+		const expectedCtors = ['True', 'False', 'Some', 'None', 'Ok', 'Err'];
+
+		for (const ctor of expectedCtors) {
+			expect(labels).toContain(ctor);
+		}
+	});
+
+	test('analysis uses the latest in-memory document content', async () => {
+		const uri = 'file:///not-on-disk.noo';
+		await harness.openDocument(uri, 'noolang', 'fn value => 1.0');
+		const floatHover = await harness.requestHover(uri, 0, 3);
+		expect(JSON.stringify(floatHover)).toContain('Float');
+
+		await harness.changeDocument(uri, 'fn value => "changed"', 2);
+		const stringHover = await harness.requestHover(uri, 0, 3);
+		expect(JSON.stringify(stringHover)).toContain('String');
+	});
+
+	test('completion includes all expected builtins', async () => {
+		const uri = 'file:///test.noo';
+		const content = '';
+
+		await harness.openDocument(uri, 'noolang', content);
+
+		const completions = await harness.requestCompletion(uri, 0, 0);
+
+		const labels = completions.map((item: any) => item.label);
+		const expectedBuiltins = ['head', 'tail', 'map', 'filter', 'reduce', 'length', 'print', 'toString', 'read', 'write', 'log', 'random'];
+
+		for (const builtin of expectedBuiltins) {
+			expect(labels).toContain(builtin);
+		}
+	});
+});

--- a/lsp/extension/test/completion.test.ts
+++ b/lsp/extension/test/completion.test.ts
@@ -4,6 +4,14 @@
 
 import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
 import { LSPServerHarness } from './harness/LSPServerHarness';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const EXPECTED_KEYWORDS = ['fn', 'if', 'then', 'else', 'match', 'with', 'variant', 'mut', 'constraint', 'implement'];
+const EXPECTED_CONSTRUCTORS = ['True', 'False', 'Some', 'None', 'Ok', 'Err'];
+const EXPECTED_BUILTINS = ['head', 'tail', 'map', 'filter', 'reduce', 'length', 'print', 'toString', 'read', 'write', 'log', 'random'];
+const FIXTURE = readFileSync(join(__dirname, 'fixtures', 'simple.noo'), 'utf8');
 
 describe('LSP Completion', () => {
 	let harness: LSPServerHarness;
@@ -18,7 +26,7 @@ describe('LSP Completion', () => {
 
 	test('returns completion items for keywords', async () => {
 		const uri = 'file:///test.noo';
-		const content = 'f';
+		const content = FIXTURE;
 
 		await harness.openDocument(uri, 'noolang', content);
 
@@ -30,7 +38,7 @@ describe('LSP Completion', () => {
 
 		// Check that we have keywords
 		const keywordItems = completions.filter((item: any) =>
-			item.kind === 14 && ['fn', 'if', 'then', 'else', 'match', 'with', 'variant', 'mut', 'constraint', 'implement'].includes(item.label)
+			item.kind === 14 && EXPECTED_KEYWORDS.includes(item.label)
 		);
 		expect(keywordItems.length).toBeGreaterThan(0);
 	});
@@ -48,7 +56,7 @@ describe('LSP Completion', () => {
 
 		// Check that we have builtin functions (kind 3 = Function)
 		const builtinItems = completions.filter((item: any) =>
-			item.kind === 3 && ['head', 'tail', 'map', 'filter', 'reduce', 'length', 'print', 'toString', 'read', 'write', 'log', 'random'].includes(item.label)
+			item.kind === 3 && EXPECTED_BUILTINS.includes(item.label)
 		);
 		expect(builtinItems.length).toBeGreaterThan(0);
 	});
@@ -66,7 +74,7 @@ describe('LSP Completion', () => {
 
 		// Check that we have constructors (kind 4 = Constructor)
 		const ctorItems = completions.filter((item: any) =>
-			item.kind === 4 && ['True', 'False', 'Some', 'None', 'Ok', 'Err'].includes(item.label)
+			item.kind === 4 && EXPECTED_CONSTRUCTORS.includes(item.label)
 		);
 		expect(ctorItems.length).toBeGreaterThan(0);
 	});
@@ -96,7 +104,7 @@ describe('LSP Completion', () => {
 		const completions = await harness.requestCompletion(uri, 0, 0);
 
 		const labels = completions.map((item: any) => item.label);
-		const expectedKeywords = ['fn', 'if', 'then', 'else', 'match', 'with', 'variant', 'mut', 'constraint', 'implement'];
+		const expectedKeywords = EXPECTED_KEYWORDS;
 
 		for (const keyword of expectedKeywords) {
 			expect(labels).toContain(keyword);
@@ -112,7 +120,7 @@ describe('LSP Completion', () => {
 		const completions = await harness.requestCompletion(uri, 0, 0);
 
 		const labels = completions.map((item: any) => item.label);
-		const expectedCtors = ['True', 'False', 'Some', 'None', 'Ok', 'Err'];
+		const expectedCtors = EXPECTED_CONSTRUCTORS;
 
 		for (const ctor of expectedCtors) {
 			expect(labels).toContain(ctor);
@@ -139,10 +147,29 @@ describe('LSP Completion', () => {
 		const completions = await harness.requestCompletion(uri, 0, 0);
 
 		const labels = completions.map((item: any) => item.label);
-		const expectedBuiltins = ['head', 'tail', 'map', 'filter', 'reduce', 'length', 'print', 'toString', 'read', 'write', 'log', 'random'];
+		const expectedBuiltins = EXPECTED_BUILTINS;
 
 		for (const builtin of expectedBuiltins) {
 			expect(labels).toContain(builtin);
+		}
+	});
+
+	test('preserves relative imports for opened workspace documents', async () => {
+		const directory = mkdtempSync(join(tmpdir(), 'noolang-lsp-import-'));
+		const mainPath = join(directory, 'main.noo');
+		writeFileSync(join(directory, 'dep.noo'), '{@answer 42}');
+		const importSource = '{@answer} = import "./dep";\nanswer';
+		writeFileSync(mainPath, importSource);
+		const repoRoot = join(__dirname, '../../..');
+		const importHarness = await LSPServerHarness.create({ workspacePath: repoRoot });
+		try {
+			const hoverUri = `file://${mainPath}`;
+			await importHarness.openDocument(hoverUri, 'noolang', importSource);
+			const hover = await importHarness.requestHover(hoverUri, 1, 1);
+			expect(JSON.stringify(hover)).toContain('Float');
+		} finally {
+			await importHarness.close();
+			rmSync(directory, { recursive: true, force: true });
 		}
 	});
 });

--- a/lsp/extension/test/fixtures/simple.noo
+++ b/lsp/extension/test/fixtures/simple.noo
@@ -1,0 +1,5 @@
+fn greet(name: String) -> String {
+  "Hello, " ++ name
+}
+
+let result = greet("world")

--- a/lsp/extension/test/harness/InMemoryTransport.ts
+++ b/lsp/extension/test/harness/InMemoryTransport.ts
@@ -1,0 +1,165 @@
+/**
+ * In-memory LSP transport for testing.
+ * Implements MessageReader and MessageWriter from vscode-jsonrpc.
+ */
+
+import { MessageReader, MessageWriter, Message } from 'vscode-jsonrpc';
+import { Event, Emitter } from 'vscode-jsonrpc';
+
+/**
+ * In-memory message queue that connects a reader and writer.
+ */
+class InMemoryQueue {
+	private messages: Message[] = [];
+	private callbacks: ((message: Message) => void)[] | null = [];
+
+	public push(message: Message): void {
+		if (this.callbacks) {
+			// If someone is listening, deliver immediately
+			for (const callback of this.callbacks) {
+				callback(message);
+			}
+		} else {
+			// Otherwise buffer
+			this.messages.push(message);
+		}
+	}
+
+	public listen(callback: (message: Message) => void): () => void {
+		if (!this.callbacks) {
+			this.callbacks = [];
+		}
+		this.callbacks.push(callback);
+
+		// Deliver any buffered messages
+		for (const message of this.messages) {
+			callback(message);
+		}
+		this.messages = [];
+
+		// Return unsubscribe function
+		return () => {
+			this.callbacks = this.callbacks?.filter(cb => cb !== callback) || null;
+		};
+	}
+
+	public close(): void {
+		this.callbacks = null;
+		this.messages = [];
+	}
+}
+
+/**
+ * In-memory MessageReader implementation.
+ */
+export class InMemoryMessageReader implements MessageReader {
+	private readonly queue: InMemoryQueue;
+	private readonly errorEmitter = new Emitter<Error>();
+	private readonly closeEmitter = new Emitter<void>();
+	private readonly partialMessageEmitter = new Emitter<any>();
+	private unsubscribe: (() => void) | null = null;
+
+	public readonly onError: Event<Error> = this.errorEmitter.event;
+	public readonly onClose: Event<void> = this.closeEmitter.event;
+	public readonly onPartialMessage: Event<any> = this.partialMessageEmitter.event;
+
+	constructor(queue: InMemoryQueue) {
+		this.queue = queue;
+	}
+
+	listen(callback: (message: Message) => void): { dispose: () => void } {
+		if (this.unsubscribe) {
+			throw new Error('Already listening');
+		}
+
+		this.unsubscribe = this.queue.listen(callback);
+		return { dispose: () => this.dispose() };
+	}
+
+	dispose(): void {
+		if (this.unsubscribe) {
+			this.unsubscribe();
+			this.unsubscribe = null;
+		}
+		this.errorEmitter.dispose();
+		this.closeEmitter.dispose();
+		this.partialMessageEmitter.dispose();
+	}
+
+	fireError(error: Error): void {
+		this.errorEmitter.fire(error);
+	}
+
+	fireClose(): void {
+		this.closeEmitter.fire();
+	}
+}
+
+/**
+ * In-memory MessageWriter implementation.
+ */
+export class InMemoryMessageWriter implements MessageWriter {
+	private readonly queue: InMemoryQueue;
+	private readonly errorEmitter = new Emitter<[Error, Message | undefined, number | undefined]>();
+	private readonly closeEmitter = new Emitter<void>();
+	private isClosed = false;
+	private writeQueue: Promise<void> = Promise.resolve();
+
+	public readonly onError: Event<[Error, Message | undefined, number | undefined]> = this.errorEmitter.event;
+	public readonly onClose: Event<void> = this.closeEmitter.event;
+
+	constructor(queue: InMemoryQueue) {
+		this.queue = queue;
+	}
+
+	async write(msg: Message): Promise<void> {
+		if (this.isClosed) {
+			throw new Error('Writer is closed');
+		}
+
+		// Ensure writes are ordered
+		this.writeQueue = this.writeQueue.then(() => {
+			if (this.isClosed) {
+				throw new Error('Writer is closed');
+			}
+			this.queue.push(msg);
+		});
+
+		return this.writeQueue;
+	}
+
+	end(): void {
+		this.isClosed = true;
+		this.closeEmitter.fire();
+	}
+
+	dispose(): void {
+		this.isClosed = true;
+		this.errorEmitter.dispose();
+		this.closeEmitter.dispose();
+	}
+
+	fireError(error: Error, message?: Message, count?: number): void {
+		this.errorEmitter.fire([error, message, count]);
+	}
+}
+
+/**
+ * Creates a pair of in-memory reader/writer for bidirectional communication.
+ */
+export function createInMemoryTransportPair(): {
+	clientReader: InMemoryMessageReader;
+	clientWriter: InMemoryMessageWriter;
+	serverReader: InMemoryMessageReader;
+	serverWriter: InMemoryMessageWriter;
+} {
+	const clientToServer = new InMemoryQueue();
+	const serverToClient = new InMemoryQueue();
+
+	return {
+		clientReader: new InMemoryMessageReader(serverToClient),
+		clientWriter: new InMemoryMessageWriter(clientToServer),
+		serverReader: new InMemoryMessageReader(clientToServer),
+		serverWriter: new InMemoryMessageWriter(serverToClient),
+	};
+}

--- a/lsp/extension/test/harness/LSPServerHarness.ts
+++ b/lsp/extension/test/harness/LSPServerHarness.ts
@@ -1,0 +1,190 @@
+/**
+ * Test harness for Noolang LSP server.
+ * Provides a simple way to start the server and send requests in tests.
+ */
+
+import { createConnection, InitializeParams, Connection } from 'vscode-languageserver/node';
+import * as path from 'path';
+import * as fs from 'fs';
+import {
+	createInMemoryTransportPair,
+	InMemoryMessageReader,
+	InMemoryMessageWriter,
+} from './InMemoryTransport';
+import { createServer } from '../../server/src/server';
+
+export interface HarnessOptions {
+	workspacePath?: string;
+	rootUri?: string;
+}
+
+/**
+ * Wraps the LSP server in a test-friendly interface.
+ */
+export class LSPServerHarness {
+	private readonly clientConnection: Connection;
+	private readonly serverConnection: Connection;
+	private isInitialized = false;
+	private readonly workspacePath: string;
+	private readonly rootUri?: string;
+
+	constructor(options: HarnessOptions = {}) {
+		// Create bidirectional transport pairs
+		const { clientReader, clientWriter, serverReader, serverWriter } = createInMemoryTransportPair();
+
+		// Create server connection (handles requests)
+		this.serverConnection = createConnection(serverReader, serverWriter);
+		// Create client connection (sends requests)
+		this.clientConnection = createConnection(clientReader, clientWriter);
+
+		const workspacePath = options.workspacePath || process.env.NOOLANG_WORKSPACE || path.resolve(process.cwd(), '../..');
+		this.workspacePath = workspacePath;
+		this.rootUri = options.rootUri;
+		const builtCli = path.join(workspacePath, 'dist', 'cli.js');
+		const sourceCli = path.join(workspacePath, 'src', 'cli.ts');
+		const cliPath = process.env.NOOLANG_CLI_PATH || (fs.existsSync(builtCli) ? builtCli : sourceCli);
+		if (!fs.existsSync(cliPath)) {
+			throw new Error(`Noolang CLI not found at ${cliPath}; build the workspace or set NOOLANG_CLI_PATH`);
+		}
+		const cliRuntime = process.env.NOOLANG_CLI_RUNTIME || (cliPath.endsWith('.ts') ? process.execPath : 'node');
+		// Use the production handlers with the in-memory connection.
+		createServer(this.serverConnection, { workspacePath, cliPath, cliRuntime });
+	}
+
+	/**
+	 * Initialize the server with mock params.
+	 */
+	async initialize(params?: Partial<InitializeParams>): Promise<void> {
+		if (this.isInitialized) {
+			throw new Error('Server already initialized');
+		}
+
+		const defaultParams: InitializeParams = {
+			processId: process.pid,
+			rootUri: this.rootUri || `file://${this.workspacePath}`,
+			capabilities: {
+				textDocument: {
+					completion: {
+						completionItem: {
+							snippetSupport: true,
+						},
+					},
+				},
+			},
+			...params,
+		};
+
+		// Start listening for messages (server handles incoming requests, client handles responses)
+		this.serverConnection.listen();
+		this.clientConnection.listen();
+
+		// Small delay to ensure listeners are set up
+		await new Promise(resolve => setTimeout(resolve, 50));
+
+		// Send initialize request from client to server
+		const result = await this.clientConnection.sendRequest('initialize', defaultParams);
+		this.isInitialized = true;
+
+		// Send initialized notification
+		await this.clientConnection.sendNotification('initialized', {});
+	}
+
+	/**
+	 * Open a document in the server.
+	 */
+	async openDocument(uri: string, languageId: string, content: string, version = 1): Promise<void> {
+		await this.clientConnection.sendNotification('textDocument/didOpen', {
+			textDocument: {
+				uri,
+				languageId,
+				version,
+				text: content,
+			},
+		});
+	}
+
+	/**
+	 * Change a document's content.
+	 */
+	async changeDocument(
+		uri: string,
+		content: string,
+		version: number,
+	): Promise<void> {
+		await this.clientConnection.sendNotification('textDocument/didChange', {
+			textDocument: {
+				uri,
+				version,
+			},
+			contentChanges: [
+				{
+					text: content,
+				},
+			],
+		});
+	}
+
+	/**
+	 * Request completion at a position.
+	 */
+	async requestCompletion(
+		uri: string,
+		line: number,
+		character: number,
+	): Promise<any> {
+		return this.clientConnection.sendRequest('textDocument/completion', {
+			textDocument: {
+				uri,
+			},
+			position: {
+				line,
+				character,
+			},
+		});
+	}
+
+	/**
+	 * Request hover at a position.
+	 */
+	async requestHover(
+		uri: string,
+		line: number,
+		character: number,
+	): Promise<any> {
+		return this.clientConnection.sendRequest('textDocument/hover', {
+			textDocument: {
+				uri,
+			},
+			position: {
+				line,
+				character,
+			},
+		});
+	}
+
+	/**
+	 * Close the harness and cleanup resources.
+	 */
+	async close(): Promise<void> {
+		if (this.isInitialized) {
+			try {
+				await this.clientConnection.sendNotification('shutdown');
+				await this.clientConnection.sendNotification('exit');
+			} catch (e) {
+				// Ignore errors during shutdown
+			}
+		}
+		this.clientConnection.dispose();
+		this.serverConnection.dispose();
+		this.isInitialized = false;
+	}
+
+	/**
+	 * Create a test harness with auto-initialization.
+	 */
+	static async create(options?: HarnessOptions): Promise<LSPServerHarness> {
+		const harness = new LSPServerHarness(options);
+		await harness.initialize();
+		return harness;
+	}
+}

--- a/lsp/extension/test/harness/TestServer.ts
+++ b/lsp/extension/test/harness/TestServer.ts
@@ -1,0 +1,3 @@
+/** @deprecated Import createServer from the production server instead. */
+export { createServer as createTestServer } from '../../server/src/server';
+export type { ServerOptions } from '../../server/src/server';

--- a/lsp/extension/test/tsconfig.json
+++ b/lsp/extension/test/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ES2020",
+    "outDir": "../out/test",
+    "rootDir": "../",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "types": ["node", "bun-types"],
+    "resolveJsonModule": true
+  },
+  "include": ["**/*", "../server/src/**/*"]
+}


### PR DESCRIPTION
> **[foreman-lite · Worker]** task: pr184-remediation-msmmqjxo

Original request: address verifier feedback on README/fixture documentation, duplicated assertions, and preserve relative-import semantics for materialized open documents.

Changes:
- Document production `createServer` integration and use the fixture in tests.
- Consolidate completion expected-label constants.
- Materialize scratch files beside writable source directories, preserving relative imports; fall back safely for unwritable paths.
- Add a relative-import regression test and Bun type dependencies; avoid compiled-output test discovery.

Checks: `cd lsp/extension && npm test`; `npm run compile`.